### PR TITLE
Add build system, with ability to generate PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+publicgoods-toolkit-v*.pdf
+publicgoods-toolkit-v*.html
+.everything.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+# Run 'make' to generate a single PDF of the current Public Goods Toolkit.
+
+# The version number is what follows the word "version" in the title.
+VERSION := `grep -o -E "version ([0-9a-zA-Z.]+)" pdf-preamble.yaml | cut -d " " -f 2`
+
+# We name the sources explicitly, instead of just saying *.md, because
+# there are some Markdown files that shouldn't be included.
+SOURCES := introduction.md community.md policy.md readiness.md procurement.md adoptability.md
+
+all: pdf
+
+html: $(SOURCES)
+	@echo "HTML output is not yet implemented."
+
+# There are three ways we control the PDF output: 
+# 
+#   1) Command-line options passed to 'pandoc' below
+#   2) Variables set in the YAML file 'pdf-preamble.yaml'
+#   3) TeX customizations supplied in 'pdf-hints.tex' (via -H below)
+#
+# These have been useful sources of help:
+# 
+#   - https://pandoc.org/MANUAL.html (of course)
+#   - https://learnbyexample.github.io/customizing-pandoc/
+#   - https://jdhao.github.io/2019/05/30/markdown2pdf_pandoc/
+#   - https://steemit.com/linux/@karaagac/\
+#     markdown-document-as-pdf-with-title-page-and-table-of-contents
+pdf: pdf-preamble.yaml $(SOURCES)
+	@rm -f .everything.md
+	@for name in pdf-preamble.yaml $(SOURCES); do                     \
+          cat $${name} >> .everything.md;                                 \
+          echo "" >> .everything.md;                                      \
+        done
+	@pandoc --pdf-engine=pdflatex                                     \
+                -f markdown-raw_tex                                       \
+                --standalone                                              \
+                -V colorlinks                                             \
+                -V urlcolor=NavyBlue                                      \
+	        -V geometry:"top=3cm, bottom=2cm, left=3cm, right=3cm"    \
+                -H pdf-hints.tex                                          \
+                --toc                                                     \
+                --toc-depth=5                                             \
+                --number-sections                                         \
+                -o publicgoods-toolkit-v$(VERSION).pdf                    \
+                .everything.md

--- a/introduction.md
+++ b/introduction.md
@@ -83,8 +83,7 @@ on:
    freely shared and are to some degree trained on open data sets and
    based on algorithms implemented in open source software.
 
-<a name="foss-licensing"></a>
-## Major Software Licenses and License Categories
+## Major Software Licenses and License Categories {#foss-licensing}
 
 At the most basic level, government agencies engaging with open source
 can start with basic knowledge of a handful of software licenses.  All

--- a/pdf-hints.tex
+++ b/pdf-hints.tex
@@ -1,0 +1,6 @@
+%%% We pass some PDF-output style hints to pandoc here rather than
+%%% in the Makefile because some hints are easier to pass this way.
+
+%% Make each section start on a new page.
+\usepackage{titlesec}
+\newcommand{\sectionbreak}{\clearpage}

--- a/pdf-preamble.yaml
+++ b/pdf-preamble.yaml
@@ -1,0 +1,4 @@
+---
+title: Public Goods Toolkit, version 0.0 (in progress)
+date: 6 July 2021
+---

--- a/policy.md
+++ b/policy.md
@@ -5,7 +5,7 @@ use and production of Digital Public Goods.  For the most part it
 discusses high-level policy considerations, while detailed policy
 recommendations are generally found in a module that is specific to
 the policy in question.  For example, procurement policies are in the
-[Procurement Module](procurement.md), and so on.
+[Procurement Module](#procurement), and so on.
 
 Many of these high-level policy considerations flow from the legal
 structures within which DPG usage and production takes place.  Among
@@ -75,8 +75,7 @@ and re-use, that is, to create an environment with a different
 default.
 
 The specifics of open source licensing are discussed in [Major
-Software Licenses and License
-Categories](introduction.md#foss-licensing).
+Software Licenses and License Categories](#foss-licensing).
 
 ### Copyright Policy
 
@@ -120,7 +119,7 @@ mind about copyright and DPGs:
 
   The question of which of these copyright ownership scenarios is best
   for a given DPG is discussed further in the [Procurement
-  Module](procurement.md).  (TBD: check Procurement to make sure we
+  Module](#procurement).  (TBD: check Procurement to make sure we
   cover this.)  The high-level policy point here is merely that the
   decision of copyright *ownership* -- which is independent from the
   choice of license -- should be made purposefully, not determined by
@@ -141,7 +140,7 @@ mind about copyright and DPGs:
   source; this is easy to find out by just checking the license, it's
   just that one must remember to do so.
 
-  As the [Procurement Module](procurement.md) discusses, it is good to
+  As the [Procurement Module](#procurement) discusses, it is good to
   write the no-proprietary-materials requirement into contracts with
   vendors, so that there is no ambiguity on the matter.  (TBD: again,
   make sure Procurement covers this.)
@@ -168,8 +167,7 @@ material should be moved here to Policy, and then the Introduction's
 coverage of that topic can be much briefer and can just point here to
 the Policy Module for details.)
 
-<a name="patent"></a>
-## Patent
+## Patent {#patent}
 
 A patent is also a monopoly right, like a copyright, but it is a
 monopoly on a method or a mechanism for doing something.  Like
@@ -208,7 +206,7 @@ However, one can at least take some steps when procuring a DPG to
 ensure that everyone involved in building it or in being an official
 distributor takes steps to avoid being a source of patent infringement
 claims themselves.  This is discussed further in the [Procurement
-Module](procurement.md).
+Module](#procurement).
 
 (TBD: link to appropriate material in Procurement Module.
 Essentially: we need to state that it's not enough to get a blessing

--- a/procurement.md
+++ b/procurement.md
@@ -1,4 +1,4 @@
-# FOSS Procurement For Government Agencies
+# FOSS Procurement For Government Agencies {#procurement}
 
 FOSS has rapidly become successful in the commercial sector.  Few
 modern enterprises can thrive without taking full advantage of open


### PR DESCRIPTION
This involved a change to how we do internal linking.  Instead of
using '<a name="foo"/>' to set an anchor ID, we now use '{#foo}' right
after the section title.  Then to refer to a section, just use its
unique ID, without including the filename.