### PR TITLE
Hyphenate "open-source" when adjective (issue #25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ The purpose of this toolkit is to provide country governments and UN-affiliated 
 
 3. **The sustainability of DPGs**: how could certain government agencies play a role in enabling innovative financial investment in DPGs so they are sustainable? 
 
-4. **The security of DPGs**: how could certain governments align an open source software with the national legal and policy frameworks especially around cybersecurity, data privacy and ownership? 
+4. **The security of DPGs**: how could certain governments align an open-source software with the national legal and policy frameworks especially around cybersecurity, data privacy and ownership? 
 
-5. **The readiness for nationwide use of DPGs**: how could certain governments build internal capacity to utilize, produce, run and maintain open source software, standards, content and AI models? How might governments encourage maintenance and incentivize quality for open source solutions and ensure that it is sustainable in a cost-effective way (i.e. requiring security audits)? 
+5. **The readiness for nationwide use of DPGs**: how could certain governments build internal capacity to utilize, produce, run and maintain open-source software, standards, content and AI models? How might governments encourage maintenance and incentivize quality for open-source solutions and ensure that it is sustainable in a cost-effective way (i.e. requiring security audits)? 
 
-6. **Procurement and Adoption**: What are low- and middle-income government procurement requirements, motivations for procurement, and the perceived risks for government related to adopting open source technologies? What are some recommendations for structuring a procurement process that is sustainable and equitable? What are open source projects that have been successfully adopted and what made them successful? 
+6. **Procurement and Adoption**: What are low- and middle-income government procurement requirements, motivations for procurement, and the perceived risks for government related to adopting open-source technologies? What are some recommendations for structuring a procurement process that is sustainable and equitable? What are open-source projects that have been successfully adopted and what made them successful? 
 
 7. **Product-Level Government Adoptability of DPGs**: What factors can governments use to evaluate the decision to deploy certain DPGs based on product-level criteria i.e. quality, maturity, security and utility?  
 
@@ -45,7 +45,7 @@ This toolkit is the work of the [UNICEF Office of Innovation](https://www.unicef
         * Guides and recommendations for creating a policy environment and structures needed for deploying and scaling open-source solutions, including cybersecurity,  data privacy and protection 
         * Frameworks and Tools for evaluating the value and costs of digital public goods, including frameworks to estimate the value of a DPG such as “social return on investment”, frameworks to evaluate both the development and ongoing costs of a DPG 
         * Readiness for a digital public good to be adopted at the country-level 
-        * Recommendations for structuring a procurement process that is suitable for open source solutions 
+        * Recommendations for structuring a procurement process that is suitable for open-source solutions 
         * Options for financing digital pubic goods as well as the related pros and cons
         * Guidance and frameworks for governments on developing relevant internal capacity within in order to scale DPGs, including the need to maintain quality 
         * A “government adoptability” tool for governments to assess the maturity and readiness for a digital public good to be adopted at the country-level 
@@ -56,7 +56,7 @@ This toolkit is the work of the [UNICEF Office of Innovation](https://www.unicef
 
 5. It is formatted  in a way such that it could be transformed into modular, interactive online website that will be user-friendly and easy to navigate.  
 
-6. It is made open source and/or published under Creative Commons – Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) where possible and unless otherwise specified 
+6. It is made open-source and/or published under Creative Commons – Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) where possible and unless otherwise specified 
 
 ## :memo: License
 

--- a/adoptability.md
+++ b/adoptability.md
@@ -1,6 +1,6 @@
 # Adoptability Assessment
 
-To evaluate an open source product for adoption, you need to look at
+To evaluate an open-source product for adoption, you need to look at
 it from several different perspectives:
 
 1. **Functionality.** Whether it has the functionality you need,
@@ -29,7 +29,7 @@ it from several different perspectives:
    project's development community?
 
 The sections that follow form a kind of checklist that you can use to
-evaluating an open source product for adoption as a DPG.  Each item in
+evaluating an open-source product for adoption as a DPG.  Each item in
 the checklist involves one or more of the above perspectives.
 
 Throughout this module we will sometimes use the word "product" and
@@ -74,7 +74,7 @@ that distinction is important we will note it.
   until after the vulnerability is fixed and a new release of the
   product has been made.  (This means that such reports are not
   normal, publicly-posted bug tickets -- a rare exception to the rule
-  that information in an open source project is all publicly visible.)
+  that information in an open-source project is all publicly visible.)
 
   HOWTO: Look at the project's web site or documentation to see what
   it says about reporting security vulnerabilities, and, if
@@ -125,7 +125,7 @@ HOWTO: [Search the CVE
   database.
 
 FURTHER READING: For a particularly clear exposition of how one large
-  open source project uses CVE numbers, see
+  open-source project uses CVE numbers, see
   [debian.org/security/cve-compatibility](https://www.debian.org/security/cve-compatibility)
   For a more detailed explanation of how CVE numbers are acquired,
   used, and evaluated, see
@@ -142,7 +142,7 @@ FURTHER READING: For a particularly clear exposition of how one large
 
 * Has the project had a professional security audit performed?
 
-  While it's not common for open source projects to have professional
+  While it's not common for open-source projects to have professional
   security audits conducted, because such audits are expensive.
   However, it happens sometimes, and when it does happen that's a very
   good sign.  The results of the audit should be publicly available
@@ -357,7 +357,7 @@ system is even extensible in more than one programming language,
 though often there is a primary supported language that most users
 prefer and that is supported best.
 
-Some well-known and widely-used open source systems owe much of their
+Some well-known and widely-used open-source systems owe much of their
 success and growth to being easily extensible in this fashion: for
 example, [WordPress](https://wordpress.org/),
 [Drupal](https://www.drupal.org/),
@@ -365,7 +365,7 @@ example, [WordPress](https://wordpress.org/),
 [MediaWiki](https://www.mediawiki.org/),
 [Firefox](https://www.mozilla.org/firefox/new/), and
 [Chromium](https://www.chromium.org/).  Extensibility has a long
-history and is not confined to open source software, however: for
+history and is not confined to open-source software, however: for
 example, AutoCAD, a system for computer-aided drafting, has had an
 extension language since the mid-1980s, and Microsoft's Visual Studio
 development environment has a rich extension community primarily
@@ -417,7 +417,7 @@ has been designed properly."
 
 ## Documentation
 
-Most open source software systems come with at least some
+Most open-source software systems come with at least some
 documentation -- that is, documentation that is officially maintained
 by the project itself, and published together with the software.  In
 many cases, there is also a wealth of scattered and heterogeneous
@@ -483,7 +483,7 @@ page), the vendor should be on that list.
 
 ## Non-Commercial Support Availability
 
-Open source projects often have quite responsive user support forums:
+Open-source projects often have quite responsive user support forums:
 places where anyone who has deployed or who uses the software can ask
 a question and get answers from experienced users.  The people who are
 subscribed to these forums are there for a variety of reasons.
@@ -575,7 +575,7 @@ vendor(s) to show where their past attempts to influence have been
 successful and how.  You can also do it directly, with a little more
 effort, by looking at the project's governance, and at the discussions
 that lead to new features and roadmap decisions.  Although any form of
-open source project governance can, in principle, be amenable to
+open-source project governance can, in principle, be amenable to
 influence, in practice projects that are run by committee are more
 reliably amenable to influence, because you have the possibility of
 being on that committee -- or, rather, of being represented on the

--- a/community.md
+++ b/community.md
@@ -1,6 +1,6 @@
 # Community And Ecosystem
 
-Each open source software project runs on the collective motivations
+Each open-source software project runs on the collective motivations
 of all of its participants.  Some of those participants may be
 "volunteers" (in the sense of not being paid directly for their work
 in the project, although even then the project is often of economic
@@ -17,7 +17,7 @@ Thus, although it is certainly accurate to refer to this collective as
 a "community" -- it has social relations, cultural norms, status
 differentiation, informal debt relations, and all the other aspects of
 human communities -- it is not a community that runs on altruism.
-Understanding how to work with and participate in an open source
+Understanding how to work with and participate in an open-source
 project is not just a matter of understanding the software at a
 technical level; it also requires understanding the motivations of the
 people who make up the project.
@@ -27,22 +27,22 @@ people who make up the project.
 One of the most important skills for agencies exploring open source is
 understanding existing ecosystems and their project's place within
 them.  In order to plan a project that builds on or collaborates with
-other open source efforts, agencies must know their own projects and
+other open-source efforts, agencies must know their own projects and
 also know what to expect from other community participants.
 
-Open source projects operate in many different ways.  Experienced open
-source practitioners build nuanced open source strategies by
-pattern-matching against other open source projects.  They use those
-patterns to understand their own projects and also the other open
-source efforts around them.  Practitioners with a lot of experience
+Open-source projects operate in many different ways.  Experienced
+practitioners of open source build nuanced open-source strategies by
+pattern-matching against other open-source projects.  They use those
+patterns to understand their own projects and also the other open-source
+efforts around them.  Practitioners with a lot of experience
 have seen many different types of projects succeed and fail in all
 kinds of situations.  Less experienced practitioners pattern match
 against a smaller set, which is to say they might have only one or a
-small handful of open source approaches and find it difficult to
+small handful of open-source approaches and find it difficult to
 perform nuanced analysis.
 
 Mozilla identified this experience gap as a general problem in open
-source, and developed a set of open source project archetypes to give
+source, and developed a set of open-source project archetypes to give
 practitioners more patterns to match against.  A given project won't
 necessarily fit perfectly into one of these archetypes, and a project
 might not reflect the same archetype(s) for its entire history --
@@ -50,15 +50,15 @@ transitions happen all the time.  In some projects, one sees multiple
 archetypes at work or even different sets of participants pushing the
 project toward separate archetypal practices.  
 
-The purpose of the archetypes is to lead people away from generic open
-source thinking and toward considering in more detail the behaviors
-and dynamics their open source investment seeks to create.  Each
+The purpose of the archetypes is to lead people away from generic
+open-source thinking and toward considering in more detail the behaviors
+and dynamics their open-source investment seeks to create.  Each
 archetype tends toward typical strategies, and categorizing projects
 by archetype can help in predicting behavior.  Similarly, where the
 strategies deviate, we can usually find deviation from the archetype
 too.  The more specific you are about what you want from open source
 in your particular context, the more you will be able to look for
-patterns and practices in successful open source projects that operate
+patterns and practices in successful open-source projects that operate
 in similar contexts.
 
 A complete discussion of each archetype is available in Mozilla's
@@ -102,7 +102,7 @@ available.)
 * [Multi-Vendor Infrastructure](https://opentechstrategies.com/archetypes-files/open-source-archetypes-v2.pdf#section*.9)
 
   When a number of commercial organizations share a common need, it
-  makes sense for them to pool their resources into one open source
+  makes sense for them to pool their resources into one open-source
   project that meets that need, rather than each one developing their
   own separate but duplicative solution.
 
@@ -111,7 +111,7 @@ available.)
 
 * [Mass Market](https://opentechstrategies.com/archetypes-files/open-source-archetypes-v2.pdf#section*.14)
 
-  An open source project aimed at very broad user adoption (for
+  An open-source project aimed at very broad user adoption (for
   example, Mozilla Firefox).  Mass Market projects often have
   commercial sponsorship of some kind, and if they are successful they
   tend to have fairly elaborate mechanisms to help steer potential
@@ -132,7 +132,7 @@ available.)
 * [Trusted Vendor](https://opentechstrategies.com/archetypes-files/open-source-archetypes-v2.pdf#section*.16)
 
   A commercial organization with unique expertise may sometimes
-  maintain an open source project that simultaneously serves to
+  maintain an open-source project that simultaneously serves to
   advertise that expertise, to maintain it, and to provide leads on
   direct or indirect sources of revenue.  Interaction with these
   projects is sometimes equivalent to interaction with that particular
@@ -157,13 +157,13 @@ available.)
 
   A single person started the project, has maintained it all along,
   and either has not wanted to or has not been able to expand its
-  developer base. (While this kind of open source project definitely
+  developer base. (While this kind of open-source project definitely
   exists, it is perhaps overrepresented in writings and public
   discussion about open source.)
 
 * [Bathwater](https://opentechstrategies.com/archetypes-files/open-source-archetypes-v2.pdf#section*.18)
 
-  A project whose source code has been published under an open source
+  A project whose source code has been published under an open-source
   license, but which is now being ignored by its original authors.
   The code was thrown over the wall, as the saying goes, and it is
   there for anyone else to pick up if they want.
@@ -185,7 +185,7 @@ available.)
 
 The most common archetype we observe in the wild is the "Wide Open"
 project.  This is normally what people think of when they imagine an
-open source project.  Wide Open projects take all comers and try to
+open-source project.  Wide Open projects take all comers and try to
 gather as much dev momentum as they can.  They skew toward shared
 governance models and cultivate a welcoming, inclusive air.  This
 approach is popular for a reason--- it's a pretty good default
@@ -193,8 +193,8 @@ starting point for a lot of projects, especially government-led open
 source.
 
 But not all projects fit that mold.  Sometimes you want to build an
-open source ecosystem and absolutely must retain a strong, controlling
-position to achieve the policy goals that drive your open source work.
+open-source ecosystem and absolutely must retain a strong, controlling
+position to achieve the policy goals that drive your open-source work.
 In industry, we see that, for example, with Google's Android work.
 There, one company makes the majority of the investment, and benefits
 by steering the majority of the mobile market to its products,
@@ -207,7 +207,7 @@ Google's strategic need.  Instead, one can classify that project as
 B2B Open Source, which is a much less inviting model.
 
 Archetypes help us identify that Android is not like a stereotypical
-open source project.  They allow us to see its actual behavior.  That
+open-source project.  They allow us to see its actual behavior.  That
 reveals something about Android's strategy and helps us form credible
 expectations about how the project will behave in the future.  It
 would be disastrous, for example, to build a product strategy that
@@ -225,8 +225,8 @@ archetypes.  All of these are candidates for projects lead by or
 originating in government agencies, depending on strategic and policy
 needs.
 
-There are other cases where archetypes help us understand the open
-source world around us.  In each case, the archetypes are a rough lens
+There are other cases where archetypes help us understand the open-source
+world around us.  In each case, the archetypes are a rough lens
 that leads us to clarify our view of a products position.  The
 archetypes, though, are just a starting point.  They are a shared
 vocabulary for a conversation that should eventually move beyond
@@ -251,7 +251,7 @@ including a mapping/analysis of some existing DPGs to the archetypes.)
 
 ## Community Diversity
 
-There are many ways to think about the diversity of an open source
+There are many ways to think about the diversity of an open-source
 project community.  Do its contributors come from a wide variety of
 geographic or cultural origins?  Do they represent a wide variety of
 skill levels?  Do they represent a wide variety of usage patterns?  Do
@@ -268,13 +268,13 @@ yet are so important to the health and success of a DPG.
 
 ## Community Health
 
-An open source community's health depends ultimately on the presence
+An open-source community's health depends ultimately on the presence
 of a user base that needs the software and is willing, directly or
 indirectly, to invest in it.  New contributors come from either those
 users or from the organizations that service those users; useful
 feature direction for the project's roadmap comes likewise from those
 users or their representatives; bug reports -- the lifeblood of an
-active open source project -- come ultimately from those users.
+active open-source project -- come ultimately from those users.
 
 The quickest way to check on the health of a project community is
 usually to look at activity over time in the bug tracker:
@@ -310,7 +310,7 @@ developers to the least, tends to correlate with project health.
 
 Moving up to a higher level of consideration, a project community
 tends to be healthier the greater the number and variety of its
-commercial participants.  In fact, at least one open source
+commercial participants.  In fact, at least one open-source
 stewardship organization has a rule that it will only accept projects
 as members if there is a sufficient diversity of employers across the
 project's individual maintainers.  Their logic is that if most of the
@@ -333,7 +333,7 @@ decisive factor unrelated to community health concerns?  See Victor's
 [answer](https://github.com/unicef/publicgoods-toolkit/pull/12#discussion_r651328070)
 to that question.)
 
-Note that many aspects of open source project community health are
+Note that many aspects of open-source project community health are
 also discussed, implicitly and sometimes explicitly, in the
 Adoptability module (TBD reference).
 
@@ -342,8 +342,8 @@ note also present in Parking Lot of Adoptability module.)
 
 ## Commercial Participants
 
-All open source licenses, by definition, allow commercial as well as
-non-commercial use of the software, and it is typical for open source
+All open-source licenses, by definition, allow commercial as well as
+non-commercial use of the software, and it is typical for open-source
 projects to have both commercial and non-commercial participants.
 Some individuals may even represent both types at different times.
 
@@ -358,7 +358,7 @@ day's feature request.
 
 This economic value is understood as such quite literally by those
 participants.  For example, when a company that is very active in an
-important open source project is the willing target of an acquisition,
+important open-source project is the willing target of an acquisition,
 it works with the acquirer to place a monetary value -- a definite
 number -- on its relationship to and influence in that project.  That
 number is partly computed by looking at the individual employees at
@@ -376,7 +376,7 @@ motivations are their own business.
 
 ## Non-Commercial Participants
 
-Depending on the open source project, there may be fewer or more
+Depending on the open-source project, there may be fewer or more
 non-commercial participants than commercial ones; it varies from
 project to project.
 
@@ -402,7 +402,7 @@ vendors of course have a commercial interest as well.  In these cases,
 there can occasionally be conflicts between the two parties'
 motivations.  For example, the NGO client may want an API capability
 that the vendor is reluctant to add because the presence of that
-capability in the open source product would reduce the value of some
+capability in the open-source product would reduce the value of some
 proprietary offering of the vendor's.
 
 There is no general formula for avoiding nor for resolving such
@@ -426,7 +426,7 @@ status in the project if they move from employer to employer.
 
 ## Sustainability, Longevity, and Lifecycle
 
-All software projects -- not just open source software projects --
+All software projects -- not just open-source software projects --
 have a lifecycle.  That lifecycle may not be knowable in advance, but
 it will eventually become apparent.  As a project matures, its rate of
 user acquisition slows down, the rate at which new contributors come

--- a/introduction.md
+++ b/introduction.md
@@ -4,7 +4,7 @@
 
 [ Do we want to mention goal-setting and strategic approaches here? ]
 
-## A Brief History of Open Source Collaboration
+## A Brief History of Open-Source Collaboration
 
 Software has always been shared.  Few significant software development
 efforts have ever been solo acts.  Early programmers tended to be
@@ -44,26 +44,26 @@ for sharing became known as "Free" or "Open Source" and more
 specifically identified as licenses that respect the [Open Source
 Definition](https://opensource.org/osd).  In the decades since,
 software made with these methods has taken over the world.  Every
-major consumer electronics product has at least some open source
+major consumer electronics product has at least some open-source
 software inside it.  It is increasingly rare to find any electronic
 device of significant complexity that is wholly proprietary.
 
-As open open source software spreads through the technology world
+As open-source software spreads through the technology world
 sector by sector, it has inspired open movements in adjacent fields
 and even distant domains.  In this set of modules, we will focus on
-open source software and related "digital public goods".  These are
+open-source software and related "digital public goods".  These are
 digital products that are freely shared in ways that invite
 permissionless copying and collaboration.
 
 The focus on DPGs necessarily excludes a variety of sectors that have
 also seen "open" progress.  Open hardware, open government, open
 science, and open organizations are all interesting applications of
-the original open source vision.  Any government agency interested in
+the original open-source vision.  Any government agency interested in
 DPGs might also be interested in those topics.  They are not DPGs,
 though, so this set of modules will not cover them.  Instead, we focus
 on:
 
- * Open Source Software - software that can be freely run, copied,
+ * Open-Source Software - software that can be freely run, copied,
    modified and distributed.
 
  * Open Standards - these are standards that are freely available to
@@ -73,7 +73,7 @@ on:
 
  * Open Content - this is content in any media that may to some degree
    be freely copied, displayed, modified or distributed, much like
-   open source software.  The most popular open content licenses are
+   open-source software.  The most popular open content licenses are
    the Creative Commons licenses.
 
  * Open Data - these are datasets that may be freely copied and
@@ -81,7 +81,7 @@ on:
 
  * Open AI Models - these are machine learning models that may be
    freely shared and are to some degree trained on open data sets and
-   based on algorithms implemented in open source software.
+   based on algorithms implemented in open-source software.
 
 <a name="foss-licensing"></a>
 ## Major Software Licenses and License Categories
@@ -100,7 +100,7 @@ the broadest range of conditions.  The more restrictive licenses are
 still quite permissive but they condition those permissions on
 compliance with certain requirements.  Among the commonly used
 licenses, those requirements concern "copyleft", which is the
-requirement that when you distribute software, open source permissions
+requirement that when you distribute software, open-source permissions
 attach to some or all of your improvements.  We usually distinguish
 between "weak" and "strong" copyleft as a way to categorize licenses
 by how strict their copyleft requirements are.
@@ -126,8 +126,8 @@ no significant restrictions.  Compliance with these licenses is
 bureaucratic, and shouldn't ever affect the substance of a project.
 For the purposes of this discussion, the key takeaway is that
 permissive licenses allow you to make *proprietary* copies.  They
-allow you to take open source code and make things that themselves are
-not open source.
+allow you to take open-source code and make things that themselves are
+not open-source.
 
 The Apache Software License is similarly permissive and similarly
 bureaucratic.  Its primary differences from the other permissive
@@ -141,8 +141,8 @@ Beyond those permissive licenses, we start to see copyleft clauses.
 "Copyleft" is a play on words.  Whereas copyright is typically used to
 prevent people from sharing software, copyleft requires that
 permission to share attach to at least some of what you build.
-Copyleft restricts your ability to make non-open source software from
-open source ingredients.  This is a bargain designed to nurture a
+Copyleft restricts your ability to make non-open-source software from
+open-source ingredients.  This is a bargain designed to nurture a
 commons of shared software-- when you distribute software that is
 built on code from the commons, sometimes that newly made software
 must join the commons too.
@@ -174,7 +174,7 @@ original.  That means that it applies not just to software that
 contains literal copies of the original but also to software that
 links to the original.  Its theory is that when you link software
 together you create a new work, and the license requires that this
-entire work be open source and carry forward the copyleft
+entire work be open-source and carry forward the copyleft
 requirements.
 
 There are two strong copyleft licenses in common use:
@@ -186,7 +186,7 @@ The AGPL differs from the GPL in one major respect.  Typically,
 copyleft rights flow through distribution.  When you transfer a copy
 of the software, copyleft requires that you give the recipient rights
 to that software.  It requires that the recipient can treat the
-software they receive as open source.  This is true for both weak and
+software they receive as open-source.  This is true for both weak and
 strong copyleft licenses.
 
 AGPL takes this one step further.  It recognizes that a lot of
@@ -194,7 +194,7 @@ software runs on servers and that most of the people who interact with
 that software will not receive a copy of it under normal
 circumstances.  AGPL tries to correct for this by requiring that if a
 user interacts with the software over a network, that user is entitled
-to receive a copy of the software and all open source rights to run,
+to receive a copy of the software and all open-source rights to run,
 copy, modify, and distribute it.
 
 ## DPGs Are About Collaboration, Not Licenses

--- a/policy.md
+++ b/policy.md
@@ -49,14 +49,14 @@ law, which we discuss [elsewhere](#patent).)
 d'auteurs" aspect of copyright law that exists in some jurisdictions.
 That may or may not be a useful detail for DPG policy.)
 
-Thus open source licenses are simply formal statements by the
+Thus open-source licenses are simply formal statements by the
 copyright holder, granting explicit permission to copy and share
-without limitation, including sharing modified versions.  Open source
+without limitation, including sharing modified versions.  open-source
 licenses originated with software, and therefore the most mature body
 of legal texts related to open licensing is found there (the
 non-software "open content" licenses are somewhat more recent,
 although at this point the oldest ones have existed for more than a
-decade and they have, like open source software licenses, undergone
+decade and they have, like open-source software licenses, undergone
 some revisions).  Importantly, the permission to share modified
 versions has been present since the beginning.  With software, the
 modifications one usually wants to make are things like fixing bugs or
@@ -65,16 +65,16 @@ improvements in one's own copy of the code -- one must be able to
 share those improvements with others in order for the code to truly be
 a Digital *Public* Good.
 
-Copyright is the main concern of the common open source licenses, and
+Copyright is the main concern of the common open-source licenses, and
 most of the terms in them are about copyright permissions.  This is
 because in the absence of explicit permissions, copyright law would be
 an obstacle to sharing software source code.  In most jurisdictions,
 copyright prohibits permissionless sharing and re-use by default,
-whereas the point of open source licensing is to allow that sharing
+whereas the point of open-source licensing is to allow that sharing
 and re-use, that is, to create an environment with a different
 default.
 
-The specifics of open source licensing are discussed in [Major
+The specifics of open-source licensing are discussed in [Major
 Software Licenses and License
 Categories](introduction.md#foss-licensing).
 
@@ -83,7 +83,7 @@ Categories](introduction.md#foss-licensing).
 From a policy perspective, there are a few major points to keep in
 mind about copyright and DPGs:
 
-* Use only well-known open source or open content licenses.
+* Use only well-known open-source or open content licenses.
 
   When publishing a DPG, you should always publish it under a
   well-known and widely-used existing license.  Never make up your own
@@ -107,7 +107,7 @@ mind about copyright and DPGs:
 
 * Establish copyright ownership clearly.
 
-  Open source licenses are still copyright licenses, and therefore
+  open-source licenses are still copyright licenses, and therefore
   they assume that the licensed work has a copyright holder.  It does
   not always matter greatly who that holder is: in some circumstances,
   it might be most appropriate for the public agency responsible for a
@@ -130,14 +130,14 @@ mind about copyright and DPGs:
 * Avoid mixing proprietary materials into a DPG.
 
   It is easy to accidentally incorporate proprietary material -- that
-  is, any copyrighted material that is *not* under an open source or
+  is, any copyrighted material that is *not* under an open-source or
   open content license -- into a DPG.  Such incorporation most often
   happens through inattention: a resource is convenient and speeds up
   development of the DPG, and only long after it has been integrated
   does someone check the license and discover that the resource is not
   redistributable in a way that is compatible with DPGs.  There are
   also occasionally popular third-party code libraries that were
-  formerly open source but whose most recent releases are not open
+  formerly open-source but whose most recent releases are not open
   source; this is easy to find out by just checking the license, it's
   just that one must remember to do so.
 
@@ -148,10 +148,10 @@ mind about copyright and DPGs:
 
 ### Copyright and Jurisdiction
 
-It is likely that these open source licenses operate in standard ways,
+It is likely that these open-source licenses operate in standard ways,
 across most countries.  Copyright law is somewhat standardized among
-Berne Convention signatory countries, and most commentators treat open
-source licenses as having the same effect regardless of jurisdiction.
+Berne Convention signatory countries, and most commentators treat open-source
+licenses as having the same effect regardless of jurisdiction.
 At the same time, these licenses were written primarily with United
 States law in mind, and few licenses have been the subject of
 official, judicial interpretation.  The one exception is version 3 of
@@ -296,7 +296,7 @@ Whether a particular DPG should have trademarks associated with it,
 and if so what the policy on ownership and enforcement of those
 trademarks should be, needs to be decided on a case-by-case basis.
 (TBD: We can point to some other resources here, such as example
-trademark policies from some existing DPGs / open source projects.
+trademark policies from some existing DPGs / open-source projects.
 https://producingoss.com/en/trademarks.html has pointers to some.)
 
 ## Commercial Use
@@ -309,7 +309,7 @@ whole, commercial investment in DPGs is usually beneficial, because
 commercial entities have more reasons to work collaboratively on the
 DPG than to try (and likely fail) to monopolize its value.
 
-The open source and open content licenses that govern DPG distribution
+The open-source and open content licenses that govern DPG distribution
 also set up an implicit economic structure that leans toward
 collaboration.  Because no entity can monopolize the DPG itself -- by
 definition, a DPG is available to all the public on equal terms -- any

--- a/procurement.md
+++ b/procurement.md
@@ -1,9 +1,9 @@
 # FOSS Procurement For Government Agencies
 
 FOSS has rapidly become successful in the commercial sector.  Few
-modern enterprises can thrive without taking full advantage of open
-source antecedents to power a competitive business.  More and more
-sectors find themselves taken over by open source offerings that crowd
+modern enterprises can thrive without taking full advantage of
+open-source antecedents to power a competitive business.  More and more
+sectors find themselves taken over by open-source offerings that crowd
 out once-dominant proprietary competitors.  It is fair to say that
 open source, once maligned by much of the commercial software world,
 has emerged victorious and is now a major component of every software
@@ -27,9 +27,9 @@ FURTHER READING: The US Government Accountability Office published a
   https://www.gao.gov/assets/600/593091.pdf
 
 This style of development is closely connected to open source: the
-availability of swappable open source components makes modular
+availability of swappable open-source components makes modular
 development not only possible but practically inevitable, and it
-rewards companies for participating in the open source projects they
+rewards companies for participating in the open-source projects they
 depend on the most.
 
 KEY RECOMMENDATION: For a good introduction to modular architecture,
@@ -40,13 +40,13 @@ KEY RECOMMENDATION: For a good introduction to modular architecture,
   which focuses on web development.
 
 Generally speaking, though, government has lagged behind.  While
-governments have begun to embrace open source approaches, actual, open
-source successes are much more rare in government than in the private
+governments have begun to embrace open-source approaches, actual
+open-source successes are much more rare in government than in the private
 sector.  There are a lot of reasons why this is the case,
 (https://producingoss.com/en/producingoss.html\#governments-and-open-source
 discusses some of those reasons.) but none of them is that open source
 is somehow unsuited for government use.  Rather, government has not
-yet spent a decade honing open source practices that take into account
+yet spent a decade honing open-source practices that take into account
 the particular needs of government software development.
 
 One place this disparity appears is in contracting.  Government has an
@@ -68,7 +68,7 @@ One center of excellence in government development of FOSS software is
 18F, the digital service delivery arm of the United States General
 Services Administration.  They focus on technology procurement for
 federal agencies, and their methodology typically begins with agile
-and open source approaches.  18F is generally considered a model
+and open-source approaches.  18F is generally considered a model
 agency when it comes to open source.  They advise federal projects to
 consider procurement based on a model of "modular contracting," (See
 https://18f.gsa.gov/tags/modular-contracting/) in which large projects
@@ -82,7 +82,7 @@ This approach has several benefits, beginning most importantly with
 breaking vendor lock-in.  At any point, a well-procured effort should
 provide recourse to multiple, credible vendors, each of whom has
 familiarity with the software, experience working with the other
-teams, and is able to work well with the agency's open source
+teams, and is able to work well with the agency's open-source
 approach.  Every vendor becomes replaceable because none by itself is
 so crucial to the process that it cannot be replaced.
 
@@ -154,12 +154,12 @@ monolithic structure would prevent.  While one *could* hire one vendor
 to build an entire system, teams that work together under one roof are
 more likely to --- indeed, almost inevitably will --- violate modular
 boundaries under deadline pressure.  Separating those teams helps
-enforce the technical boundaries that keep open source process
+enforce the technical boundaries that keep open-source process
 functioning. Another approach to enforcing modular separation is
 through OSQA, described below.
 
 KEY RECOMMENDATION: Modular contracting works best with agile,
-  open source development and modular technical design.
+  open-source development and modular technical design.
 
 One aspect of modular contracting that is sometimes overlooked is that
 it can be costly to conduct many smaller rounds of procurement.  Even
@@ -183,8 +183,8 @@ contracting place those contract modules in larger Master Services
 Agreements ("MSAs") while also encouraging vendors to seek
 multiple contract modules under their MSA.  In addition, one can
 increase the size of modules as a project proceeds.  Once a project
-has a set of vendors who understand the product, demonstrate open
-source expertise, and have established a track record of delivering
+has a set of vendors who understand the product, demonstrate open-source
+expertise, and have established a track record of delivering
 quality work on time, the benefits of modular contracting decrease
 while the costs remain elevated.  At that point, one might opt for
 larger contract modules, especially as the project grows in scope.
@@ -221,7 +221,7 @@ contract.  Open source is competitive, and is driving wholly proprietary
 approaches out of the market.
 
 There are three classes of software delivered in a typical procurement
-scenario: third-party open source software, pre-existing
+scenario: third-party open-source software, pre-existing
 vendor-created software, and code custom-written by the vendor for the
 current project.  Notice this list does not include any third-party
 proprietary software.
@@ -233,7 +233,7 @@ KEY RECOMMENDATION: Contracts should expressly forbid satisfying
 These different types of software are to some degree distinguishable
 for procurement purposes, but might be intermingled in the source
 code.  We distinguish them at contracting just to ensure government
-agencies have the rights they need to proceed with their open source
+agencies have the rights they need to proceed with their open-source
 plans and never needs to secure a vendor's permission to operate,
 improve, or hire other parties to work on the software.  This is the
 key point.
@@ -241,14 +241,14 @@ key point.
 KEY RECOMMENDATION: No matter what happens with intellectual
   property rights at the contracting stage, " + client + " must have
   the ability to deploy, distribute, and modify the software under a
-  suitable open source license.
+  suitable open-source license.
 
-For third-party open source software, this means that an agency must
+For third-party open-source software, this means that an agency must
 receive that software, clearly labeled, in a manner compliant with
-their original open source license and under terms that are compatible
+their original open-source license and under terms that are compatible
 with the intended license of the final product.  For code written by
 the vendor for other engagements and not paid for by the contracting
-agency, this means delivered to the agency under open source license
+agency, this means delivered to the agency under an open-source license
 that allows redistribution under the intended license of the final
 product.  There is no need for an agency to gain exclusive rights to
 these classes of software.
@@ -256,8 +256,8 @@ these classes of software.
 For code written by a vendor and paid for by an agency, the question
 of who should end up owning the rights is up for debate.  Some
 agencies might be willing to see those rights remain in the vendor's
-hands as long as they receive an open source license that allows
-further distribution under the intended open source terms of the final
+hands as long as they receive an open-source license that allows
+further distribution under the intended open-source terms of the final
 product.  So long as an agency secures those rights, it does not much
 matter who holds the copyright.  Common practice, though, appears to
 be that the contracting agency ultimately gains all rights.  In some
@@ -268,72 +268,73 @@ its ability to make proprietary use of the software.  Specific
 arrangements will vary, but there is no harm in them so long as a) the
 terms serve a larger goal of fostering a multi-vendor ecosystem, and
 b) the agency always has full rights, including redistribution rights,
-under the desired outbound open source license.
+under the desired outbound open-source license.
 
 As an example, the County of Los Angeles in California, engaged a
-vendor, Smartmatic, to build new open source voting machines that
+vendor, Smartmatic, to build new open-source voting machines that
 debuted during the primary elections in March of 2020.  LA owns the
 resulting software and hardware designs, and Smartmatic enjoys a
 period of exclusive ability to use proprietary licensing to exploit
 the designs in the market.  At the same time, LA is moving toward
-granting the public open source access to these materials.  Smartmatic
+granting the public open-source access to these materials.  Smartmatic
 will have the proprietary rights it wants as it tries to sell the
 system in other jurisdictions.  While it will eventually have to
-compete with the open source crowd, it is welcome to build a
+compete with the open-source crowd, it is welcome to build a
 proprietary business if it can do so under such conditions.  Officials
 in LA hope this will help create the demand that entices more
 participants to join the effort.  Other public-spirited projects in
 which a primary vendor predominates have either considered or adopted
 similar arrangements.
 
-It is worth making one final point about rights.  Open source licenses
+It is worth making one final point about rights.  open-source licenses
 commonly deal with copyrights.  They do not adequately address
 trademarks and are uneven in their handling of patents.  Contracts
 must secure terms that prevent a vendor from encumbering further
 development and distribution on either trademark or patent grounds.
 
-## Open Source Quality Assurance
+## Open-Source Quality Assurance
 
 In addition to intellectual property clauses, we recommend using
-procurement structures to emphasize open source development *process*.
-A vendor who merely delivers a timely set of open source components
+procurement structures to emphasize open-source development *process*.
+A vendor who merely delivers a timely set of open-source components
 has not actually done enough to succeed at contributing to a
-successful open source project.  In addition to writing quality open
-source code, the vendor must enable all the other teams to succeed by
-participating in and reinforcing the open source process.
+successful open-source project.  In addition to writing quality open-source
+code, the vendor must enable all the other teams to succeed by
+participating in and reinforcing the open-source process.
 
 Some vendors will be unable to manage this participation.  They won't
-have the open source experience or, in some cases, the temperament.
-No matter how much an agency might prefer experienced open source
+have the open-source experience or, in some cases, the temperament.
+No matter how much an agency might prefer experienced open-source
 vendors during the procurement process, it is likely that at least
 some vendors will end up on the team because they submitted bids that
-scored high on non-open source criteria.  To succeed, an agency cannot
-assume all its vendors will have the open source skills they need.
+scored high on non-open-source criteria.  To succeed, an agency cannot
+assume all its vendors will have the open-source skills they need.
 The agency can instead provide structures that ensure success even
-when relying on vendors who might otherwise fall short in their open
-source practice.
+when relying on vendors who might otherwise fall short in their open-source
+practice.
 
 Similarly, some vendors will be *unwilling* to participate in
 good faith.  That is, they will be willing to check boxes on the
 paperwork, but behaviorally will default to the type of closed
 development process typically found in government contracts.
-Sometimes this unwillingness comes from a lack of experience and open
-source skill.  In some other cases, perhaps, a vendor may hope the
-open source process fails, which could result in a final product that,
-while technically open source, cannot actually be released as open
-source, or that resists open source dynamics, thus leaving the vendor
+Sometimes this unwillingness comes from a lack of experience and
+open-source skill.  In some other cases, perhaps, a vendor may hope the
+open-source process fails, which could result in a final product that,
+while technically open-source, cannot actually be released as open-source,
+or that resists open-source dynamics, thus leaving the vendor
 as the sole practical source for that component in the government
 procurement marketplace.
 
-Whatever the reason for failure to participate in an open source process,
+Whatever the reason for failure to participate in an open-source process,
 agencies must have ways to bring recalcitrant vendors into process
 compliance.  Otherwise, the project risks failure across multiple
-teams.  To prepare for such situations, we recommend instituting Open
-Source Quality Assurance ("OSQA") at the project management level.
+teams.  To prepare for such situations, we recommend instituting
+Open-Source Quality Assurance ("OSQA") at the project management
+level.
 
-OSQA is a set of practices designed to ensure that an open source
-project *behaves* like an open source project.  If vendors are
-delivering open source code but not engaging in the process, the
+OSQA is a set of practices designed to ensure that an open-source
+project *behaves* like an open-source project.  If vendors are
+delivering open-source code but not engaging in the process, the
 software will hit some of its milestones but fail as collaboration
 falters over time.  Adding new vendors will be difficult.  Teams will
 discover API mismatches when they try to integrate modular pieces.
@@ -377,7 +378,7 @@ the project that cannot be achieved any other way.  That credibility
 will pay dividends in every meeting, progress checkin, and contract
 negotiation, by alerting external contributors (and especially
 vendors) that the procuring agency understands every aspect of the
-work.  It will also help ensure that open source processes are
+work.  It will also help ensure that open-source processes are
 followed in spirit as well as in letter, since lapses will be more
 readily apparent.
 
@@ -385,19 +386,19 @@ readily apparent.
 KEY RECOMMENDATION: client + " should participate directly in
   technical development, even if only to a small degree, in order to
   create credibility and connection with vendors and contractors and
-  to contribute to maintaining a consistent open source culture.
+  to contribute to maintaining a consistent open-source culture.
 
 Furthermore, by requiring OSQA to sign off on code submissions, an
 agency can enforce standards in the one way that vendors cannot
 ignore: it stands between vendors and reaching their contracted
-deliverables.  That is, it allows an agency to enforce open source
+deliverables.  That is, it allows an agency to enforce open-source
 process compliance as a condition of being paid on time.
 
 KEY RECOMMENDATION: client + " should require acceptance of code
-  into the open source repository as part of the definition of
+  into the open-source repository as part of the definition of
   contractual delivery in software milestones.
 
-At every stage, the software should be ready for open source
+At every stage, the software should be ready for open-source
 engagement, and OSQA is an agency's assurance that this is true.
 
 Sitting on the tree is only one aspect of an OSQA program.  There are
@@ -418,9 +419,9 @@ OSQA has a track record of success in government agencies.  We have
 performed OSQA and seen it work well at several levels of government,
 from federal to local.  In one instance, OSQA was begun long after the
 primary development vendor had begun work, and it was too late to
-establish open source practices from day one.  Instead, the OSQA team
+establish open-source practices from day one.  Instead, the OSQA team
 worked with the vendor and the procuring agency to identify process
-failures and teach open source best practices.  Over time, vendor
+failures and teach open-source best practices.  Over time, vendor
 participants as well as agency staff began to reap the benefits of
 investing in the process.  After some time, teams embraced the process
 because it paid visible dividends (eventually including independent
@@ -435,9 +436,9 @@ Putting OSQA at the coordination center of a project allows OSQA to
 both enforce standards and also shape the process and lead by example.
 It also puts it in a good position to play a role as advocate for an
 agency in evaluating contractor decisions and proposals.  Ultimately,
-learning by example is how well-functioning open source projects set
+learning by example is how well-functioning open-source projects set
 norms, and as project development finds its rhythm, one can also
-expect less-experienced open source vendors to learn from the others.
+expect less-experienced open-source vendors to learn from the others.
 
 
 ## Staffing
@@ -499,7 +500,7 @@ Elections to approve anything the week before an election.
 
 Finally, there is another approach worth mentioning but not
 recommending.  If an agency did not have any goals with regard to
-growing the pool of open source contractors to include more small
+growing the pool of open-source contractors to include more small
 businesses, it might, as some large companies do, impose a rule that
 the vendor cannot depend on the agency for more than a certain
 percentage of its revenue.  This might result in a preference for
@@ -507,7 +508,7 @@ contractors large enough to absorb the cost of carrying under-utilized
 developers, or vendors large enough to have other projects with short
 term needs for those developers to fill.  This might work, though we
 have only seen it used in the private sector, not the public sector.
-In any event, cultivating open source contractors usually demands
+In any event, cultivating open-source contractors usually demands
 learning to work with smaller firms, so we hesitate to recommend this
 approach in most instances.
 
@@ -589,20 +590,20 @@ KEY RECOMMENDATION: while operation might be a separate line-item,
   improvement that keeps software current and prevents an agency from
   having to start over.
 
-## Open Source Solicitation
+## Open-Source Solicitation
 
 Modular contracting often can be done in small enough contracts that
 streamlined procurement processes are available. At some point,
 though, an agency may want to embark on a larger project that does not
 easily fit into a "small contracting" budgeting provision.  In that
 case, it will need to operate an RFP process.  This section contains
-information on open source concerns that should be considered during
+information on open-source concerns that should be considered during
 that process.
 
 The RFP process is another aspect of procurement that government
 agencies might improve.  A common pitfall is beginning an RFI and RFP
 process with high hopes for choosing vendors eager to provide agile,
-open source development in a public spirit of building
+open-source development in a public spirit of building
 multi-jurisdictional software.  Unfortunately, RFP responses often
 include a long list of traditional vendors who are not eager to work
 in this manner and perhaps lack the experience needed to do so well.
@@ -617,22 +618,22 @@ This failure pattern appears at all levels of government and in many
 different types of agencies.  The truth is that even as governments
 are still gaining sophistication with open source, the commercial
 FOSS world is also still gaining maturity in navigating
-government procurement systems.  Many open source development
+government procurement systems.  Many open-source development
 companies, especially smaller and less traditional ones, do not have
-procedures that let them discover open source opportunities at early
+procedures that let them discover open-source opportunities at early
 stages.  If government is to succeed at open source, it needs to
 expand the pool of RFP respondents.
 
 KEY RECOMMENDATION: It is more important to attract bids from
-  vendors who are experienced at open source development than to
+  vendors who are experienced at open-source development than to
   attract vendors who are experienced at government contracting.
 
 There are several strategies procurement agencies use in this regard:
 
 First, it pays to ensure that solicitations are promoted in media
-aimed at open source developers, not just at government software
+aimed at open-source developers, not just at government software
 vendors.  An agency might maintain a list of community connectors who
-can promote a solicitation to a wider open source audience.  It is
+can promote a solicitation to a wider open-source audience.  It is
 important to conduct this outreach early in the process, because newer
 vendors will need more time than government-experienced vendors to
 prepare responses. (Although it goes without saying, it is worth
@@ -643,13 +644,13 @@ KEY RECOMMENDATION: Conduct FOSS-specific outreach early in the
   RFP lifecycle.
 
 Second, it is important to be clear in describing project requirements
-and emphasizing the need for open source deliverables, process, and
+and emphasizing the need for open-source deliverables, process, and
 experience.  The phrase "open source" applies in contexts other than
 software (e.g., open source intelligence), so be sure to spell out the
-full phrase "open source software" for vendors searching the web or
+full phrase "open-source software" for vendors searching the web or
 databases for opportunities.  The types of vendors an agency hopes to
-attract will be sophisticated about the differences between open
-source software, open data, and agile development.  Be specific and
+attract will be sophisticated about the differences between open-source
+software, open data, and agile development.  Be specific and
 strategic in using these terms, and back them up with questions
 designed to elicit experience in these domains.
 
@@ -657,10 +658,10 @@ Third, if using modular contracting, make sure vendors understand the
 breadth of solicitations so they can understand both their specific
 bid and the overall process.
 
-Fourth, open source vendors expect agile, iterative development.  A
+Fourth, open-source vendors expect agile, iterative development.  A
 traditional RFP process often asks vendors to envision the entire
 engagement and price it as a whole, which requires a degree of
-pre-planning that open source modular contracting is specifically
+pre-planning that open-source modular contracting is specifically
 designed to avoid.  Craft a process that is clear about goals and
 requirements but leaves room for vendors to meet them in flexible ways
 that might change over the course of the project.   This
@@ -686,10 +687,10 @@ KEY RECOMMENDATION: Include in contracts a process (and budget)
   for iterative process and lightweight changes that do not require
   giving up other features and milestones.
 
-In talking to open source software development vendors, it is clear
+In talking to open-source software development vendors, it is clear
 that there are many capable firms that would provide excellent service
 to government agencies.  Too many of these firms avoid responding to
 RFPs because they cannot navigate the process.  Agencies can procure
-from experienced open source vendors by leading more of these vendors
+from experienced open-source vendors by leading more of these vendors
 into the government services space and fostering competition in FOSS
 service delivery.

--- a/readiness.md
+++ b/readiness.md
@@ -1,14 +1,14 @@
-# Open Source Readiness
+# Open-Source Readiness
 
 Open source is a powerful tool that offers great benefits to agencies
 that make, maintain, or deploy software.  Agencies are increasingly
-aware that they need open source capabilities.  The hard part is
+aware that they need open-source capabilities.  The hard part is
 knowing where to start in adding skills.  In most cases, the most
 important consideration is building capability to know how and when to
 use FOSS strategies.
 
-Open source is all about execution.  Reaping the benefits of open
-source investment requires completing a series of difficult steps
+Open source is all about execution.  Reaping the benefits of open-source
+investment requires completing a series of difficult steps
 ranging from designing an initial strategy to building an appropriate
 community to leveraging the resulting dynamics for strategic
 advantage.  Most government procurement teams are not yet prepared to
@@ -22,12 +22,12 @@ To do that, we might locate current capabilities in a readiness model.
 This clarifies where an agency is in its journey to mastery and also
 suggests next steps and likely results.  Often, teams use these models
 to identify areas for potential growth.  They are most useful for
-those early in their open source progress, and this module focuses on
+those early in their open-source progress, and this module focuses on
 those beginning stages.  It is useful for an agency to consider its
 maturity on an organization wide basis, but open source is usually
 executed by teams, and it is the capabilities of specific teams that
 matter most.  This module considers individual teams as the target for
-analysis because even agency-wide open source skills training will
+analysis because even agency-wide open-source skills training will
 succeed or fail mostly at the level of specific teams working on
 specific projects.
 
@@ -50,7 +50,7 @@ As you can see, there are a number of such models.  It is often worth
 considering more than one when examining an organization or a
 particular team.  Of the published models, we find McAffer's in
 particular is useful because it includes strategic components.  It
-accounts for realistic failure modes, and understands that open source
+accounts for realistic failure modes, and understands that open-source
 readiness will be unevenly distributed in any agency large enough to
 have multiple teams.
 
@@ -59,21 +59,21 @@ FURTHER READING Microsoft Senior Director Jeff McAffer (now Senior Director at G
   useful readiness model at
   https://mcaffer.com/2019/02/Open-source-engagement
 
-On many teams, initial open source capabilities might be nascent.
+On many teams, initial open-source capabilities might be nascent.
 Most team members have not had significant (or perhaps even any)
-experience using open source strategies to create value.  The team
+experience using open-source strategies to create value.  The team
 works in an environment where FOSS investment is rare, and many do not
 see much reason to change that.  That lack of knowledge might
 translate in some quarters into hostility toward FOSS.  People will
 say "It can never work here" even as open source slowly seeps into
 more and more of the technology around them.
 
-At this stage, open source strategies will be difficult to execute.
+At this stage, open-source strategies will be difficult to execute.
 Internal political risks might be high.  Policies needed to engage
 open source productively might be missing.  Staff might not know how
-to begin working with external open source contributors.  Many people
-might lack even a basic understanding of what it means to do open
-source work.  Efforts to work in an open source mode suffer from an
+to begin working with external open-source contributors.  Many people
+might lack even a basic understanding of what it means to do open-source
+work.  Efforts to work in an open-source mode suffer from an
 increased risk of failure, and they might fail in ways that reinforce
 the belief that open source is not worth further consideration.
 
@@ -85,16 +85,16 @@ costs and risks of refusing to engage start to rise, pressure to
 engage open source will increase.
 
 Those costs might include the pain of maintaining internal forks of
-external open source projects. Or more commonly, the risks of not
+external open-source projects. Or more commonly, the risks of not
 maintaining all those forks.  Similarly, the benefits of making minor
-open source investments start to become clear, even if only because
+open-source investments start to become clear, even if only because
 other teams will begin to reap those benefits and your team gains
 good, internal examples to follow.
 
 However any specific team begins to adapt, climbing the learning curve
-is often an exercise in experimentation.  Most don't think of open
-source investment in those terms.  Instead, they cast initial open
-source forays as making small concessions to necessity.  Some see
+is often an exercise in experimentation.  Most don't think of open-source
+investment in those terms.  Instead, they cast initial open-source
+forays as making small concessions to necessity.  Some see
 these experiments as seizing unique, non-repeatable advantages.  Most
 don't think of those small, initial projects as the future direction
 of the team.  More teams should consider the possibility, though.
@@ -105,17 +105,17 @@ learning.  It gives permission to fail.  Those can be useful to teams
 seeking adaptability.  When considering McAffer's model, we might
 relabel his "tolerance" phase as "experimentation".
 
-KEY RECOMMENDATION: Look for the places where your lack of open source
+KEY RECOMMENDATION: Look for the places where your lack of open-source
   investment are causing problems that can be addressed by
   small-scale, low-risk, experimental engagement.  Start there.
 
 Experiments come in many forms, but the most common first experiment
-is using some outside open source code and engaging the open source
+is using some outside open-source code and engaging the open-source
 project.  That might involve filing bug reports, offering a
 contribution, or merely participating in project mailing lists and
 forums.  These are all relatively low-risk, low-investment ways to
 begin connecting a team to outside FOSS projects.  If your team's
-future plans include larger-scale open source engagement, building
+future plans include larger-scale open-source engagement, building
 skills through these kinds of small-scale experiments can be very
 productive.
 
@@ -132,16 +132,16 @@ and experience.  This is a pivotal, risky moment.  A large number of
 teams will still be in the initial phases.  Efforts to move internal
 culture toward open source will be perceived by some as a pointless
 shift toward the latest buzzword.  Those experimental skills will be
-unevenly distributed internally.  Many new open source projects will
+unevenly distributed internally.  Many new open-source projects will
 fail, and this will convince some that all open source is destined to
-fail.  In some agencies, some might even sabotage open source projects
+fail.  In some agencies, some might even sabotage open-source projects
 for policy or political reasons.
 
 McAffer sees this phase as one of hype, and perhaps that's because
 it's also when an agency embraces open source without quite being
 ready to execute.  Agencies in this phase tend to engage FOSS in
 shallow, unsophisticated ways simply because they don't yet have the
-experience to make better strategic use of open source opportunities.
+experience to make better strategic use of open-source opportunities.
 The way to move past this stage is not to reduce the hype (though that
 might help) but rather to increase readiness.
 
@@ -162,19 +162,19 @@ resources.  Agencies that fail to provide this support from fairly
 high in the organization tend to level off at this level of readiness.
 
 Another consideration for agencies climbing the readiness ladder is
-that the need for skilled open source practitioners will almost always
-exceed the supply.  The demand for open source skills is growing so
-fast, the world does not have enough experienced open source
+that the need for skilled open-source practitioners will almost always
+exceed the supply.  The demand for open-source skills is growing so
+fast, the world does not have enough experienced open-source
 strategists and developers to keep up.  A number of companies and
 universities have decided to address this problem by centralizing much
-of their open source expertise in an Open Source Programs Office
+of their open-source expertise in an Open Source Programs Office
 (OSPO).  The OSPO's job is to use that collected expertise to improve
-open source readiness and efficacy across the entire organization.  We
+open-source readiness and efficacy across the entire organization.  We
 are not aware of any agencies that have an OSPO, but governments
-should consider focusing open source readiness efforts on one agency
+should consider focusing open-source readiness efforts on one agency
 or department that can then help others.  In the United States, the
 federal government did this with 18F, which, after reaching relatively
-high levels of open source capability and knowledge, has developed
+high levels of open-source capability and knowledge, has developed
 guidance for other agencies approaching open source. Code.gov has created a [toolkit](https://github.com/GSA/code-gov-open-source-toolkit) that goes in-depth for approaching open source.
 
 All of the above describes a path from the very beginning toward


### PR DESCRIPTION
I'm creating this pull request for convenience of review, but my recommendation is to *not* merge it.

Now that I see how awkward most places become with the hyphenation, I understand better why popular usage has so overwhelmingly gone the other way (a few early documents like the OSD notwithstanding).

While there is a grammatical consistency argument for hyphenating it as a compound adjective, it's not actually ambiguous when not hypenated, and there are many situation in which it does better to retain its noun flavor while serving as an adjective (e.g., "Open Source Quality Assurance (OSQA)" is a set phrase).  The reason there is no ambiguity is that "source" on its own is never a plausible adjective, at least in the contexts where "open source" is being used as an adjective.

So this PR is for examination, but let's discuss and decide whether we really want to merge it.  Empirically, hyphenation is not how the majority of writing in English on the 'Net does it, and I tend to assume the crowd has at least *some* wisdom in these matters.