### PR TITLE
Add "DPG" acronym at first chance in two modules

### DIFF
--- a/introduction.md
+++ b/introduction.md
@@ -51,7 +51,7 @@ device of significant complexity that is wholly proprietary.
 As open open source software spreads through the technology world
 sector by sector, it has inspired open movements in adjacent fields
 and even distant domains.  In this set of modules, we will focus on
-open source software and related "digital public goods".  These are
+open source software and related "digital public goods" (DPGs).  These are
 digital products that are freely shared in ways that invite
 permissionless copying and collaboration.
 

--- a/policy.md
+++ b/policy.md
@@ -1,7 +1,7 @@
 # Policy
 
 This module is about how to design public agency policies to encourage
-use and production of Digital Public Goods.  For the most part it
+use and production of Digital Public Goods (DPGs).  For the most part it
 discusses high-level policy considerations, while detailed policy
 recommendations are generally found in a module that is specific to
 the policy in question.  For example, procurement policies are in the


### PR DESCRIPTION
This addresses a comment first made (in PR #13) about the Introduction,
but addresses it in the Policy module as well as in the Introduction;
there are currently no other modules where this change is needed.

Note that the expansion is capitalized differently in each place.  I
think that's okay, but even if it were something we wanted to fix,
fixing it would be separate from adding the acronym.