### PR TITLE
Updates to key recommendations  + examples

### DIFF
--- a/adoptability.md
+++ b/adoptability.md
@@ -2,27 +2,56 @@
 
 
 **KEY RECOMMENDATION**: When evaluating an open source product for
-adoption, look at its functionality, technical
-quality, and availability of support as well as the project's sustainability and responsiveness to its user base.
+adoption, look at its functionality, technical quality, and
+availability of support as well as the project's sustainability and
+responsiveness to its user base.
   
-**KEY RECOMMENDATION**: A project that's likely to develop a secure-as-possible product should have: a documented process for reporting security vulnerabilities; security patch releases; updated third-party dependencies; and possibly a Common Vulnerability Exposure number(s) (CVE) and a published security audit. 
+**KEY RECOMMENDATION**: A project that's likely to develop a
+secure-as-possible product should have: a documented process for
+reporting security vulnerabilities; security patch releases; updated
+third-party dependencies; and possibly a Common Vulnerability Exposure
+number(s) (CVE) and a published security audit.
 
-EXAMPLE: The financial inclusion DPG [Mifos](https://mifos.org/) has a [CVE](https://www.opencve.io/cve/CVE-2021-21385) related to the Mifos-Mobile Android Application for MifosX. The problem has been fixed, but the public documentation is a sign of a mature project that takes security seriously and is willing to enlist the support of global security researchers and developers to build a better product. The DHIS2 DPG also publishes [CVEs, along with a clear process for reporting vulnerabilities](https://dhis2.org/security).
+EXAMPLE: The financial inclusion DPG [Mifos](https://mifos.org/) has a
+[CVE](https://www.opencve.io/cve/CVE-2021-21385) related to the
+Mifos-Mobile Android Application for MifosX. The problem has been
+fixed, but the public documentation is a sign of a mature project that
+takes security seriously and is willing to enlist the support of
+global security researchers and developers to build a better
+product. The DHIS2 DPG also publishes [CVEs, along with a clear
+process for reporting vulnerabilities](https://dhis2.org/security).
 
-**KEY RECOMMENDATION**: The existence of vendors providing commercial support is practically a guarantee that the product is as stable
-and reliable as possible. If you are considering working with one of these vendors,
-you should find solid public evidence of their contributions to the product. 
+**KEY RECOMMENDATION**: The existence of vendors providing commercial
+support is practically a guarantee that the product is as stable and
+reliable as possible. If you are considering working with one of these
+vendors, you should find solid public evidence of their contributions
+to the product.
 
-EXAMPLE: The digital ID DPG [MOSIP](https://www.mosip.io/) supports a thriving community of several dozen commercial partners, such as [systems integrators and biometric solution providers](https://www.mosip.io/resource-partners/mosip-integrations). MOSIP's first fully functional release was in [February 2020, and its 1.2 long-term support version will be released soon](https://www.mosip.io/news-events/announcing-general-availability-of-mosip-release-1-1). 
+EXAMPLE: The digital ID DPG [MOSIP](https://www.mosip.io/) supports a
+thriving community of several dozen commercial partners, such as
+[systems integrators and biometric solution
+providers](https://www.mosip.io/resource-partners/mosip-integrations). MOSIP's
+first fully functional release was in [February 2020, and its 1.2
+long-term support version will be released
+soon](https://www.mosip.io/news-events/announcing-general-availability-of-mosip-release-1-1).
 
+**KEY RECOMMENDATION**: Thorough product installation and initial
+configuration documentation indicates a product that's actually meant
+to be used. A documented Application Programming Interface (API) is
+often important to supporting the full range of the programmatic
+functionality you'll probably need, especially if you will work with
+data at scale (although a lack of published APIs isn't uncommon for
+early stage open source products, but if this is the case, they should
+be on the project's roadmap). Relatedly, be sure to get a detailed
+understanding the product's ability to import/export data, as you will
+surely need to work with legacy data at some point. Data portability
+also enables you to switch systems or vendors, should the need arise.
 
-**KEY RECOMMENDATION**: Thorough product installation and initial configuration documentation indicates a product that's actually meant to be used. A documented Application Programming Interface (API) is often important to supporting the full range of the programmatic functionality you'll probably need, especially if you will work with data at scale (although a lack of published APIs isn't uncommon for early stage open source products, but if this is the case, they should be on the project's roadmap). Relatedly, be sure to get a detailed understanding the product's ability to import/export data, as you will surely need to work with legacy data at some point. Data portability also enables you to switch systems or vendors, should the need arise.
-
-EXAMPLE: The health information management system DPG DHIS2 publishes clear [documentation about installation and configuration as well as its Web API](https://docs.dhis2.org/en/home.html), which enables external systems (e.g. third-party software, web portals, and other internal DHIS2 modules) to securely access and manipulate DHIS2 data.
-
-
-
-
+EXAMPLE: The health information management system DPG DHIS2 publishes
+clear [documentation about installation and configuration as well as
+its Web API](https://docs.dhis2.org/en/home.html), which enables
+external systems (e.g. third-party software, web portals, and other
+internal DHIS2 modules) to securely access and manipulate DHIS2 data.
 
 A lot of open source products are available as
 commercial-off-the-shelf solutions; often they are fairly
@@ -118,7 +147,9 @@ that distinction is important we will note it.
 
   A good example of a [clearly documented process is from the Fedora
   Project](https://fedoraproject.org/wiki/Security_Bugs), whose Fedora
-  Linux is part of the DPG Resources collection. The DHIS2 DPG also publishes a [clear process for reporting vulnerabilities](https://dhis2.org/security).
+  Linux is part of the DPG Resources collection.  The DHIS2 DPG also
+  publishes a [clear process for reporting
+  vulnerabilities](https://dhis2.org/security).
 
   **KEY RECOMMENDATION**: Look at the project's web site or
   documentation to see what it says about reporting security
@@ -220,7 +251,7 @@ that distinction is important we will note it.
   such as adherence to national regulation, as well as the software
   itself, but they're still useful resources. The National Audit
   Office of Estonia [recently audited
-  X-Road(™)](https://eurosai-it.org/news/newsletter/1-2021/updates-from-itwg-members/estonia-x-road-and-audit)
+  X-Road](https://eurosai-it.org/news/newsletter/1-2021/updates-from-itwg-members/estonia-x-road-and-audit)
   and found that implementing agencies weren't adhering to some of the
   security policies we recommend in the Policy module (TBD: link)
 
@@ -271,10 +302,11 @@ have a very strong interest in the software's stability: unstable
 software costs them money, because it requires their staff to do more
 interrupt-driven work.
 
-**KEY RECOMMENDATION**: The existence of vendors providing commercial support is practically a guarantee that the product is as stable
-and reliable as possible. Looking through public reviews and a project's
-bug report database will also give you an idea of a product's stability and
-reliability. 
+**KEY RECOMMENDATION**: The existence of vendors providing commercial
+support is practically a guarantee that the product is as stable and
+reliable as possible. Looking through public reviews and a project's
+bug report database will also give you an idea of a product's
+stability and reliability.
 
 ## Scalability and Deployment Investment
 
@@ -770,43 +802,67 @@ very useful to have in-house, even if you also have a support vendor.)
 
 ## Internal Capacity Assessment
 
-
 TBD: Plan for this section is to collect the relevant points from all
 the other sections and examine what specific internal capacities would
 be needed to take advantage of or implement the advice given in those
 points.]
 
-[SUSY NOTE: I think OTS's deep implementation experience is needed here to outline what's most important and what's often overlooked in thinking about internal capacity. I started to draft some categories for how I'd approach this but I'm not sure I'm able to get to most salient and experiential-based insight]
+TBD from Susy: I think OTS's deep implementation experience is needed
+here to outline what's most important and what's often overlooked in
+thinking about internal capacity. I started to draft some categories
+for how I'd approach this but I'm not sure I'm able to get to most
+salient and experiential-based insight.  Draft categories:
 
-(draft categories)
+- Skills + capabilities (personnel resources)
 
--Skills + capabilities (personnel resources)
---Want to build base of knowledge and a community of practice, open source skills in personnel  
---https://producingoss.com/en/producingoss.html#funding-non-programming
+  + Want to build base of knowledge and a community of practice, open
+    source skills in personnel
 
---Don't forget phasing of project and skills you might need at different times. investing for influence can build up over time. staffing and vendors + modular contracts, see Procurement, also thoughts on budget for ongoing maintenance and operations
+  + https://producingoss.com/en/producingoss.html#funding-non-programming
 
---external relationships + partnerships (Mozilla as failure example with mobile OS) are ideally run in-house
+  + Don't forget phasing of project and skills you might need at
+    different times. investing for influence can build up over
+    time. staffing and vendors + modular contracts, see Procurement,
+    also thoughts on budget for ongoing maintenance and operations
 
---running privacy and security audits 
+  + external relationships + partnerships (Mozilla as failure example
+    with mobile OS) are ideally run in-house
 
---legal + regulatory compliance - specialized. don't surprise them https://producingoss.com/en/contracting.html#rfi-rfp-contract-language; [Everything a government attorney needs to know about open source software licensing](https://ben.balter.com/2014/10/08/open-source-licensing-for-government-attorneys/). The purpose of the document is to provide government legal counsel with a brief primer (not legal advice) on open source licenses.
+  + running privacy and security audits 
 
---resources to support scalability (see above section)
+  + legal + regulatory compliance - specialized. don't surprise them
+    https://producingoss.com/en/contracting.html#rfi-rfp-contract-language;
+    [Everything a government attorney needs to know about open source
+    software
+    licensing](https://ben.balter.com/2014/10/08/open-source-licensing-for-government-attorneys/).
+    The purpose of the document is to provide government legal counsel
+    with a brief primer (not legal advice) on open source licenses.
+
+  + resources to support scalability (see above section)
 
 - OSQA project roles, if don't have this internal should plan for this from vendor
 
 
--Culture
-George quote:"You can tackle infrastructure, but the cultural issues are the harder ones." 
-appendix re: culture and coding in the open 
+- Culture
 
--Processes + policies - general org health things of course, like strategy formation, clear decision making, accountability etc ; also eventually building open source related processes and policies. Templates to follow in license reviews, 
+  George quote: "You can tackle infrastructure, but the cultural
+  issues are the harder ones."
 
--Tools -- this concern is more if you are creating an entirely new open source community. start w/ communicatoins tools, source code management, issue tracker. Point to existing resources here. OSQA related tools? https://producingoss.com/en/technical-infrastructure.html;  https://todogroup.org/guides/management-tools/#why-you-need-special-tools-for-open-source-program-management
+  appendix re: culture and coding in the open 
 
+- Processes + policies - general org health things of course, like
+  strategy formation, clear decision making, accountability etc ; also
+  eventually building open source related processes and
+  policies. Templates to follow in license reviews,
 
+- Tools -- this concern is more if you are creating an entirely new
+  open source community. start w/ communicatoins tools, source code
+  management, issue tracker. Point to existing resources here. OSQA
+  related tools?
 
+  https://producingoss.com/en/technical-infrastructure.html;
+
+  https://todogroup.org/guides/management-tools/#why-you-need-special-tools-for-open-source-program-management
 
 ## Ecosystem Mapping for Adoptability
 

--- a/adoptability.md
+++ b/adoptability.md
@@ -1,90 +1,28 @@
 # Adoptability Assessment
 
-TBD: If we're going to start out a section with a list of key
-recommendations, maybe we should organize the recommendations into
-topical groups?  When they're presented as one long, undifferentiated
-list, that's a lot to absorb.
 
 **KEY RECOMMENDATION**: When evaluating an open source product for
-adoption, the key areas to look at are functionality, technical
-quality, availability of support, the project's sustainability, and
-the project's responsiveness to its user base.
+adoption, look at its functionality, technical
+quality, and availability of support as well as the project's sustainability and responsiveness to its user base.
   
-**KEY RECOMMENDATION**: Look at the project's web site or
-documentation to see what the project says about reporting security
-vulnerabilities.  If applicable, ask the vendor.
+**KEY RECOMMENDATION**: A project that's likely to develop a secure-as-possible product should have: a documented process for reporting security vulnerabilities; security patch releases; updated third-party dependencies; and possibly a Common Vulnerability Exposure number(s) (CVE) and a published security audit. 
 
-**KEY RECOMMENDATION**: Look at the project's release history and see
-if there are any security patch releases.  Their presence would
-indicate that the project is handling security vulnerabilities at
-least at a base level of competency.  and see if there are any
-security patch releases, which would indicate that the project is
-handling security vulnerabilities at least at a base level of
-competency.
+EXAMPLE: The financial inclusion DPG [Mifos](https://mifos.org/) has a [CVE](https://www.opencve.io/cve/CVE-2021-21385) related to the Mifos-Mobile Android Application for MifosX. The problem has been fixed, but the public documentation is a sign of a mature project that takes security seriously and is willing to enlist the support of global security researchers and developers to build a better product. The DHIS2 DPG also publishes [CVEs, along with a clear process for reporting vulnerabilities](https://dhis2.org/security).
 
-**KEY RECOMMENDATION**: [Search the CVE
-list](https://cve.mitre.org/find/search_tips.html) to see how
-well-represented the product you're considering is in the CVE
-database.
+**KEY RECOMMENDATION**: The existence of vendors providing commercial support is practically a guarantee that the product is as stable
+and reliable as possible. If you are considering working with one of these vendors,
+you should find solid public evidence of their contributions to the product. 
 
-**KEY RECOMMENDATION**: Confirm that third-party dependencies are up-to-date.
+EXAMPLE: The digital ID DPG [MOSIP](https://www.mosip.io/) supports a thriving community of several dozen commercial partners, such as [systems integrators and biometric solution providers](https://www.mosip.io/resource-partners/mosip-integrations). MOSIP's first fully functional release was in [February 2020, and its 1.2 long-term support version will be released soon](https://www.mosip.io/news-events/announcing-general-availability-of-mosip-release-1-1). 
 
-**KEY RECOMMENDATION**: See if any security audits are publicly available.  
 
-**KEY RECOMMENDATION**: Looking through public reviews and a project's
-bug report database will give you an idea of a product's stability and
-reliability. The existence of vendors providing commercial support for
-the product is practically a guarantee that the product is as stable
-and reliable as possible.
+**KEY RECOMMENDATION**: Thorough product installation and initial configuration documentation indicates a product that's actually meant to be used. A documented Application Programming Interface (API) is often important to supporting the full range of the programmatic functionality you'll probably need, especially if you will work with data at scale (although a lack of published APIs isn't uncommon for early stage open source products, but if this is the case, they should be on the project's roadmap). Relatedly, be sure to get a detailed understanding the product's ability to import/export data, as you will surely need to work with legacy data at some point. Data portability also enables you to switch systems or vendors, should the need arise.
 
-**KEY RECOMMENDATION**: As a general rule, the more scalability you
-need, the more up-front investment you must make in configuring your
-deployment. Take this into account in your resource planning.
+EXAMPLE: The health information management system DPG DHIS2 publishes clear [documentation about installation and configuration as well as its Web API](https://docs.dhis2.org/en/home.html), which enables external systems (e.g. third-party software, web portals, and other internal DHIS2 modules) to securely access and manipulate DHIS2 data.
 
-**KEY RECOMMENDATION**: Be sure to get a detailed understanding the
-product's ability to import/export data. Even if you have a vendor
-supporting you, search the Internet and the project's forums for
-reports from others about importing and exporting the data formats
-that matter to you. This will help you plan for needed resources and
-project scheduling as well as be better prepared should you need to
-switch vendor support at some point.
 
-**KEY RECOMMENDATION**: Having a documented API as part of a service
-is very important to supporting a full range of the functionality
-you'll likely need.  Check documentation and search for examples on
-the Internet of people using that API to accomplish real-world tasks.
-Lack of published APIs isn't uncommon for early stage open source
-products, but then they should be planned for on the project's
-roadmap.  APIs are necessary in any product intended to work with data
-at scale.
 
-**KEY RECOMMENDATION**: Extensibility is often a sign of maturity in
-open source products.  When a product evolves to meet the needs of a
-variety of users, it usually does so by having a stable core, with
-flexibility achieved through pluggable extensions that meet specific
-user needs.  Thus, when you are evaluating vendors for an extensible
-system, seek vendors that have demonstrated experience in writing such
-extensions.
 
-**KEY RECOMMENDATION**: Look at the products's installation and
-initial configuration documentation.  If this deployment documentation
-is missing, or is obviously incomplete, that is a warning sign about
-the entire product. When working with vendors, beware of those who try
-to steer you to their proprietary documentation for functionality that
-is part of the public product.
-
-**KEY RECOMMENDATIONS**: It's a good sign if an open source product
-has commercial support around it, such as consulting and development
-companies. If you are considering working with one of these vendors,
-you should find solid public evidence of their contributions and
-engagement.
-
-**KEY RECOMMENDATION**: User support forums are useful resources in
-your evaluation. Don't hesistate to ask questions.
-
-**KEY RECOMMENDATION**: Open source projects have lifecycles, and the
-maturity level of a project will generally dictate your ability to
-influence and level/type of investment needed.
 
 A lot of open source products are available as
 commercial-off-the-shelf solutions; often they are fairly
@@ -180,7 +118,7 @@ that distinction is important we will note it.
 
   A good example of a [clearly documented process is from the Fedora
   Project](https://fedoraproject.org/wiki/Security_Bugs), whose Fedora
-  Linux is part of the DPG Resources collection.
+  Linux is part of the DPG Resources collection. The DHIS2 DPG also publishes a [clear process for reporting vulnerabilities](https://dhis2.org/security).
 
   **KEY RECOMMENDATION**: Look at the project's web site or
   documentation to see what it says about reporting security
@@ -217,10 +155,9 @@ that distinction is important we will note it.
 
   This may sound surprising, but if a project has a history of
   obtaining CVE numbers for vulnerabilities, for example as the DPG
-  Apache Fineract does
-  (https://www.cvedetails.com/vulnerability-list/vendor_id-45/product_id-42731/Apache-Fineract.html),
+  [Apache Fineract does](https://www.cvedetails.com/vulnerability-list/vendor_id-45/product_id-42731/Apache-Fineract.html),
   that's actually a *good* sign: it means the project is integrated
-  into the wider community of global computer security response, and
+  into the wider community of global computer security response and
   is following the standard procedures.
 
   Note that if a project has many CVE numbers associated with it, that
@@ -283,7 +220,7 @@ that distinction is important we will note it.
   such as adherence to national regulation, as well as the software
   itself, but they're still useful resources. The National Audit
   Office of Estonia [recently audited
-  X-Road](https://eurosai-it.org/news/newsletter/1-2021/updates-from-itwg-members/estonia-x-road-and-audit)
+  X-Road(™)](https://eurosai-it.org/news/newsletter/1-2021/updates-from-itwg-members/estonia-x-road-and-audit)
   and found that implementing agencies weren't adhering to some of the
   security policies we recommend in the Policy module (TBD: link)
 
@@ -334,11 +271,10 @@ have a very strong interest in the software's stability: unstable
 software costs them money, because it requires their staff to do more
 interrupt-driven work.
 
-**KEY RECOMMENDATION**: Looking through public reviews and a project's
-bug report database will give you an idea of a product's stability and
-reliability. The existence of vendors providing commercial support for
-the product is practically a guarantee that the product is as stable
-and reliable as possible.
+**KEY RECOMMENDATION**: The existence of vendors providing commercial support is practically a guarantee that the product is as stable
+and reliable as possible. Looking through public reviews and a project's
+bug report database will also give you an idea of a product's stability and
+reliability. 
 
 ## Scalability and Deployment Investment
 
@@ -346,7 +282,7 @@ An important part of evaluating a DPG is to evaluate the investment
 your team must make to deploy the DPG *in a way that meets your
 requirements*.
 
-**KEY RECOMMENDATION**: As a general rule, the more scalability you
+**RECOMMENDATION**: As a general rule, the more scalability you
 need, the more up-front investment you must make in configuring your
 deployment.
 
@@ -400,7 +336,7 @@ time of the evaluation and procurement that that legacy data exists.
 And there are many reasons why you might be interested in exporting
 data even if you are not migrating away from the system to something
 else (see the section "Programmatic Control (APIs)" [Programmatic
-Control (APIs)](TBD: link to section above) for more about these).
+Control (APIs)](TBD: link to section below) for more about these).
 Moreover, open projects must ensure they [support extraction or
 importation of non-PII data in a non-proprietary
 format](https://digitalpublicgoods.net/standard/) in order to qualify
@@ -591,7 +527,7 @@ prefer vendors that have demonstrated experience writing extensions,
 especially vendors who are well-represented in the public marketplace
 (if any exists) of extensions that may be used with the system.
 
-**KEY RECOMMENDATION**: An open source product's extensibility is
+**RECOMMENDATION**: An open source product's extensibility is
 often a sign of maturity, as it's developed enough to have a stable
 foundation and pushes flexibility through extensions that can change
 more often to meet more specific, and varied, user needs. When you are
@@ -614,9 +550,9 @@ Most open source software systems come with at least some
 documentation -- that is, documentation that is officially maintained
 by the project itself and published together with the software.  Such
 documentation is actually a [DPG
-requirement](https://digitalpublicgoods.net/standard; see
-[MOSIP](https://docs.mosip.io/platform/architecture/data-architecture)
-for a good documentation example). In many cases, there is also a
+requirement](https://digitalpublicgoods.net/standard); see
+[MOSIP](https://docs.mosip.io/platform/)
+for a good example. In many cases, there is also a
 wealth of scattered and heterogeneous third-party documentation:
 "HOWTO" blog posts, answers posted on sites like [Stack
 Overflow](https://stackoverflow.com/), etc.
@@ -647,7 +583,7 @@ focus on improving the project's documentation rather than maintaining
 a separate, non-open-source set of documentation that's just for their
 customers.
 
-**KEY RECOMMENDATION**: Look at the products's installation and
+**KEY RECOMMENDATION**: Look at the product's installation and
 initial configuration documentation.  If this deployment documentation
 is missing, or is obviously incomplete, that is a warning sign about
 the entire product. When working with vendors, beware of those who try
@@ -682,7 +618,7 @@ the discussion/support forums.
 
 If the project has a vendor listing page (see, for example,
 [Mojaloop's business
-directory](https://mojaloop.io/business-directory/), the vendor should
+directory](https://mojaloop.io/business-directory/)), the vendor should
 be on that list.
 
 **KEY RECOMMENDATIONS**: It's a good sign if an open source product
@@ -734,7 +670,7 @@ moved from https://discourse.mifos.org to Slack?  Or this is a good
 point for OSQA section.  Apache Fineract's all seemed old, 2018].
 Mojaloop also seemed pretty thin.)
 
-**KEY RECOMMENDATION**: User support forums are useful resources in
+**RECOMMENDATION**: User support forums are useful resources in
 your evaluation. Don't hesistate to ask questions.
 
 ## Influence and Participation
@@ -786,7 +722,7 @@ committee by an existing member.  Recall too that open source projects
 later in their lifecycle are often less open to influence, as they
 will generally prioritize stability.  This is usually true for modular
 projects as well, although their exensibility does give you a path for
-influence (see [Community](/unicef/publicgoods-toolkit/community).
+influence (see the [Community](/unicef/publicgoods-toolkit/community) module).
 
 Project governance documents
 are useful insofar as they describe the formal structure of how
@@ -840,6 +776,7 @@ the other sections and examine what specific internal capacities would
 be needed to take advantage of or implement the advice given in those
 points.]
 
+[SUSY NOTE: I think OTS's deep implementation experience is needed here to outline what's most important and what's often overlooked in thinking about internal capacity. I started to draft some categories for how I'd approach this but I'm not sure I'm able to get to most salient and experiential-based insight]
 
 (draft categories)
 
@@ -858,7 +795,6 @@ points.]
 --resources to support scalability (see above section)
 
 - OSQA project roles, if don't have this internal should plan for this from vendor
-
 
 
 -Culture
@@ -886,7 +822,7 @@ them.
 
 When you're about to make an investment in a DPG, such as by deploying
 it for sustained use, it can be very helpful to take a step back and
-explicitly map out that ecosystem, in a quick, lightweight exercise.
+explicitly map out that ecosystem, in a quick, lightweight exercise. (This exercise is equally useful in planning to create a new DPG.)
 
 Making such a map can reveal both gaps and opportunities.  For
 example, an ecosystem map might reveal a gap by showing that the main
@@ -915,7 +851,7 @@ of date, and that's okay.  Just hand-draw it on paper or on a
 whiteboard.
 
 Here is a map drawn to identify stakeholders in the [Arches
-Project](https://archesproject.org/) -- the original was hand-drawn,
+Project](https://archesproject.org/). The original was hand-drawn,
 but we cleaned up a bit for publication:
 
 ![Ecosystem map for the Arches Project (https://archesproject.org/).](images/example-ecosystem-map-768x550.png)
@@ -962,10 +898,7 @@ Ecosystem mapping can reveal gaps in the landscape. For example,
 such support is important and the ecosystem does not provide it, you
 will have to find anther way to fill this gap.
 
-KEY RECOMMENDATION: with a simple ecosystem map as the background,
-consider what project archetypes might fit well within that ecosystem.
-Identify which ones might be missing and which ones you wouldn't
-expect to appear.
+**RECOMMENDATION**: A simple ecosystem map can help you think through what other adoptability factors might be relevant. What in the ecosystem actors, their types, and their distribution gives you additional insight? For the project's likely archetype, what would you expect to see in that ecosystem? Are there problematic gaps or useful opportunties? 
 
 
 ## Evaluation Checklist

--- a/appendix-examples.md
+++ b/appendix-examples.md
@@ -162,10 +162,10 @@ collaborating on common digital infrastructure useful to each
 state. In 2017, it founded the Nordic Digital Infrastructure Institute
 to help govern and foster the joint development of basic e-service
 infrastructure across regional partners. Estonia, Finland and Iceland
-are members. Estonia moved the governance of X-Road, its open
+are members. Estonia moved the governance of X-Road(™), its open
 source data exchange software that powers much of its government
 e-services, to this new organization, along with a few other
-components. X-Road is under an MIT license, but the trademark is
+components. X-Road(™) is under an MIT license, but the trademark is
 still held by the Estonian government, giving them the essential tool
 for protecting trust in the technology.
 
@@ -175,7 +175,7 @@ Estonia’s Public Information Act prohibits government agencies from
 creating separate databases to collect and store the same data, and
 it's actually illegal for new public e-services to design systems that
 store the same data in different repositories. In combination with the
-creation of X-Road data exchange platform, this integrated approach
+creation of X-Road(™) data exchange platform, this integrated approach
 drives remarkable efficiency as well as data security and protection.
 
 In June 2021, **Estonia began [enforcing
@@ -228,6 +228,8 @@ commit e4bf35a12d0).  It would need some more more work before being
 moved out of the parking lot and into actual examples.  But also, are
 these DPGs at all?  We may not want to use them as examples.
 
+SUSY RESPONSE: These were all highlighted by the speaker from India at the recent UN/DPG meeting but I had the same question (esp Aadhar) so I was starting to summarize and investigate more. 
+
 * Aadhar (https://uidai.gov.in/) 12-digit unique identification (UID)
   with no need for physical card.  It is the largest biometric digital
   database covering more than 1.25 billion residents, including more
@@ -273,6 +275,8 @@ an area of early open source DPG collaboration. The UK's Government
 Digital Service launched [GOV.UK](https://github.com/alphagov), a
 platform for hosting government websites and information, as its first
 project (It now hosts several e-services as well)
+
+[SUSY NOTE: I think the following is already in the resources + tools appendix]
 
 ## Additional Resources + Tools
 

--- a/appendix-examples.md
+++ b/appendix-examples.md
@@ -98,7 +98,7 @@ exists (and it exist quite often), there is an opportunity to develop
 an open source approach that eases the path to compliance for all
 states.
 
-### Open Source and Collaboration : Canada’s Covid Exposure Notifications Mobile App
+### Open Source and Collaboration : Canada's Covid Exposure Notifications Mobile App
 
 The Canadian Digital Service (CDS) is a centralized resource for the
 federal Canadian government that builds tools, technologies and
@@ -111,7 +111,7 @@ MIT license in order to encourage broad collaboration and greater
 reusability across potential open -- or proprietary -- downstream
 projects.**
 
-When the Covid-19 pandemic hit, the **CDS’s familiarity with open
+When the Covid-19 pandemic hit, the **CDS's familiarity with open
 source enabled them to quickly bring in private partners, such as
 Shopify, Blackberry, and the non-profit consortium the Linux
 Foundation, and work across multiple government agencies** to create a
@@ -127,7 +127,7 @@ a privacy-preserving way. The Linux Foundation Public Health managed
 an open and public security audit.
 
 
-### Policy : Estonia’s E-Government Services
+### Policy : Estonia's E-Government Services
 
 Estonia is famous for its pioneering work in [digitizing almost all
 government services](https://e-estonia.com/) in order to build more
@@ -138,17 +138,17 @@ direct investment and economic development policy, regulation, and
 even foreign policy to drive and support development of the necessary
 open IT infrastructure.**
 
-Estonia’s earliest guidance focused on how to efficiently build
+Estonia's earliest guidance focused on how to efficiently build
 interoperable infrastructure that was thoughtfully user-centric. Open
 standards for interoperability, use of open source solutions and
-attention to privacy were key points of guidance. Most of Estonia’s
+attention to privacy were key points of guidance. Most of Estonia's
 e-services software is now open source. The government eventually
 created an [e-state code repository for its
 software](https://koodivaramu.eesti.ee/users/sign_in):
-koodivaramu.eesti.ee (based on open source GitLab). It’s notable that
+koodivaramu.eesti.ee (based on open source GitLab). It's notable that
 this code repository was created by the Ministry of Economic Affairs
 as well as the Information Systems Authority, as **a key goal of the
-government’s use of open source -- as well as of open data, available
+government's use of open source -- as well as of open data, available
 through [the Open Government Data Portal](https://avaandmed.eesti.ee/)
 -- is to encourage the private sector to also develop public
 services**, (commercial or non-commercial).
@@ -162,20 +162,20 @@ collaborating on common digital infrastructure useful to each
 state. In 2017, it founded the Nordic Digital Infrastructure Institute
 to help govern and foster the joint development of basic e-service
 infrastructure across regional partners. Estonia, Finland and Iceland
-are members. Estonia moved the governance of X-Road(™), its open
+are members. Estonia moved the governance of X-Road, its open
 source data exchange software that powers much of its government
 e-services, to this new organization, along with a few other
-components. X-Road(™) is under an MIT license, but the trademark is
+components. X-Road is under an MIT license, but the trademark is
 still held by the Estonian government, giving them the essential tool
 for protecting trust in the technology.
 
 Estonia planned thoughtfully for how their policies should
 specifically support their open technology approach. For example,
-Estonia’s Public Information Act prohibits government agencies from
+Estonia's Public Information Act prohibits government agencies from
 creating separate databases to collect and store the same data, and
 it's actually illegal for new public e-services to design systems that
 store the same data in different repositories. In combination with the
-creation of X-Road(™) data exchange platform, this integrated approach
+creation of X-Road data exchange platform, this integrated approach
 drives remarkable efficiency as well as data security and protection.
 
 In June 2021, **Estonia began [enforcing
@@ -189,7 +189,7 @@ code repository, free to the public**, with limited exceptions.
 ### Open Source Readiness : United States Web Design System
 
 A recommendation in evaluating Open Source Readiness -- and in moving
-up the ‘readiness ladder’ -- is to **look for places where
+up the 'readiness ladder' -- is to **look for places where
 collaboration through open source co-development could address common
 problems through small-scale, low-risk and even experimental
 engagements. Solving common problems can drive quick efficiencies and
@@ -228,7 +228,9 @@ commit e4bf35a12d0).  It would need some more more work before being
 moved out of the parking lot and into actual examples.  But also, are
 these DPGs at all?  We may not want to use them as examples.
 
-SUSY RESPONSE: These were all highlighted by the speaker from India at the recent UN/DPG meeting but I had the same question (esp Aadhar) so I was starting to summarize and investigate more. 
+SUSY RESPONSE: These were all highlighted by the speaker from India at
+the recent UN/DPG meeting but I had the same question (esp Aadhar) so
+I was starting to summarize and investigate more.
 
 * Aadhar (https://uidai.gov.in/) 12-digit unique identification (UID)
   with no need for physical card.  It is the largest biometric digital
@@ -257,94 +259,9 @@ SUSY RESPONSE: These were all highlighted by the speaker from India at the recen
   facing app. 874m vaccinations reported through app. Instant vacc
   certifications. 25m in one day! Pm has made this available to anyone
 
-### TBD: WIP material from Susy's PR #39 branch -- Karl will check with her
-
-In the course of resolving conflicts while merging the 'susyedits'
-branch (see PR #39), there was some material that was removed on the
-branch (i.e., would be lost from 'main') that I wasn't sure Susy meant
-to be removed -- for example, it might just be that it had been added
-on main after she branched and overlapped with changes she made.  That
-material started right after the "United States Web Design" section
-above (the part ending with "from non-profit organizations, like Code
-for America").  Here it is, with just some light formatting fixes:
-
-(TODO: see if can find cost analysis of this work)
-
-Infrastructure for web site development and management has often been
-an area of early open source DPG collaboration. The UK's Government
-Digital Service launched [GOV.UK](https://github.com/alphagov), a
-platform for hosting government websites and information, as its first
-project (It now hosts several e-services as well)
-
-[SUSY NOTE: I think the following is already in the resources + tools appendix]
-
-## Additional Resources + Tools
-
-**Cultural + Security Considerations When Coding In The Open**
-
-As noted throughout this toolkit, it's important to think through the
-cultural shifts required for an open project to succeed, from roughly
-evaluating a project's ecosystem to assessing internal
-capacity. Regulation, policies and processes can set the boundaries of
-an environment and influence behaviour, but the execution is still up
-to individual human choice. Public servants know this well.
-
-There are innumerable books on leading through change in government as
-well as industry. A simple but effective approach from the more
-business-oriented Leadership on the Line (Ronald A. Heifetz, Marty
-Linsky, 2002, p 55) is: Distinguish technical from adaptive changes
-Find out where people are at Listen to the song beneath the words Read
-the behaviour of authority figures for clues.
-
-Open source co-development often requires new tools and processes, and
-that change must be supported by the organization's culture. Recognize
-that some will feel a loss around this and will need guidance. At its
-heart, open source collaboration requires communicating and coding in
-the open. This transparency can bring the benefits outlined throughout
-this document, but it also opens the project -- and its human
-participants -- to being called out more easily for mistakes.
-
-[Section 3.5] of the document reviewed security policy considerations
-and gave some and [Section 6.1] of the document reviewed how to
-evaluate the security of an existing open source project in order to
-understand risk in adoption. But what about protecting the ongoing
-security of a project, or deciding if one's own work should be open
-sourced? One of the greatest fears of any technology developer -- or
-any public servant -- is to somehow jeopardize a project's security
-and thus potentially harm real people. This understandable fear is
-behind many government agencies' wariness of open source. How can an
-agency decide what code should stay proprietary because of security
-concerns? What if a mistake is made in the open? Isn't open source
-code a security vulnerability?
-
-The UK government has publicly wrangled with these issues and come up
-with useful guidance. It's notable that their stance on how much code
-to develop through an open source model has changed from “most” to
-“all, with very limited exceptions.” In short, their experience taught
-them that open sourcing code was actually a great way to confirm and
-enhance security, perhaps even particularly for code related to
-managing security. When following and enforcing [strong security
-design](https://www.ncsc.gov.uk/collection/cyber-security-design-principles),
-such as ensuring configuration files are kept separately from code,
-open peer review improves security. An open source project that in
-itself is about security or privacy should follow
-
-The UK's guidance [Security Considerations When Coding in the
-Open](https://www.gov.uk/government/publications/open-source-guidance/security-considerations-when-coding-in-the-open)
-is a concise, clear checklist for developers and program managers that
-links to other useful resources, such as how to manage software
-dependencies and the value of automated style enforcement. These
-checklist items are:
-
-* Open the code early
-* Don't rely on closed code as your only security measure
-* Follow good development practices
-* Keep keys and credentials closed
-* Assume accidental publications are compromised
-* Deal with security vulnerabilities
-
-Their [approach to when code should be kept closed](https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed) is similarly straightforward:
-
-* Data and code related to keys and credentials
-* Algorithms used to detect fraud
-* Unreleased policy should be kept closed.
+* Infrastructure for web site development and management has often
+  been an area of early open source DPG collaboration. The UK's
+  Government Digital Service launched
+  [GOV.UK](https://github.com/alphagov), a platform for hosting
+  government websites and information, as its first project (It now
+  hosts several e-services as well)

--- a/appendix-resources-tools.md
+++ b/appendix-resources-tools.md
@@ -4,134 +4,294 @@ Additional resources and tools are listed by topical module.
 
 TBD: Question from Karl for Susy: I'd like to better understand the
 purpose of this appendix and how it relates to the other appendices.
+Well, as per our discussion on 2021-10-13, we're maybe going to create
+some more topic-specific appendixes, so some of this will get moved to
+one of those then.
 
 ## **Introduction**
 
-[TODO: add a few resources for networking  -- hoping OTS can think of this quickly. Maybe think about this from a topic viewpoitn (open source, open data, AI)
+(TBD: Write introductory paragraphs.  Add a few resources for
+networking if possible.
 
-OECD policy-focused AI Policy Observatory https://www.oecd.ai/
-Open Data Handbook from the Open Knowledge Foundation  https://opendatahandbook.org/
- as well as regional:
-Europe lists some, many useful globally too - https://joinup.ec.europa.eu/collection/open-source-observatory-osor/about
-Africa regions
-South America
-India 
+* OECD policy-focused AI Policy Observatory -- https://www.oecd.ai/
+* Open Data Handbook from the Open Knowledge Foundation --  https://opendatahandbook.org/
+* Europe lists some, many useful globally too -- https://joinup.ec.europa.eu/collection/open-source-observatory-osor/about
+* Africa regions
+* South America
+* India
+
+Maybe think about this from a topic viewpoint, e.g., open source, open
+data, AI.)
 
 The [Open Source Initiative](https://opensource.org/community) is a good resource and hosts several mailing lists. 
 
-You might also start by connecting with your local university, especially if there's a computer science or data science program. Open source and open data are also heavily relied upon in other disciplines, like physics and public policy programs and business schools. [DHIS2's early focus on building academic and regional networks]( https://digitalpublicgoods.net/blog/the-transformative-role-of-academia-digital-public-goods/) is a great example here. Academic institutions are another source of useflu national and international networks. You're also likely to find talent and support at any sort of commercial start-up accelerator or incubator, which if not physically local might still be accessible and helpful to you online. 
-
+You might also start by connecting with your local university,
+especially if there's a computer science or data science program. Open
+source and open data are also heavily relied upon in other
+disciplines, like physics and public policy programs and business
+schools. [DHIS2's early focus on building academic and regional
+networks](
+https://digitalpublicgoods.net/blog/the-transformative-role-of-academia-digital-public-goods/)
+is a great example here. Academic institutions are another source of
+useflu national and international networks. You're also likely to find
+talent and support at any sort of commercial start-up accelerator or
+incubator, which if not physically local might still be accessible and
+helpful to you online.
 
 **Benefits of Open Source**
-- The World Bank report [Open Source for Global Public Goods](https://openknowledge.worldbank.org/handle/10986/33401) (2019) provides an overview of the benefits of open source along with sensible operational advice, especially for resource-constrained environments, and a few case studies of Identification for Development (ID4D)  esp in resource-constrained environments. More on It reiterates many of the same points we note here, such the benefits of open APIs and a modular architecture. 
 
-- [Open Source Software Finds its Sweet Spot in the Public Sector](https://www.publicsectorexecutive.com/Public-sector-focus/open-source-software-finds-its-sweet-spot-in-the-public-sector-)
+* The World Bank report [Open Source for Global Public
+  Goods](https://openknowledge.worldbank.org/handle/10986/33401)
+  (2019) provides an overview of the benefits of open source along
+  with sensible operational advice, especially for
+  resource-constrained environments, and a few case studies of
+  Identification for Development (ID4D)  esp in resource-constrained
+  environments. More on It reiterates many of the same points we note
+  here, such the benefits of open APIs and a modular architecture.
+
+* [Open Source Software Finds its Sweet Spot in the Public
+  Sector](https://www.publicsectorexecutive.com/Public-sector-focus/open-source-software-finds-its-sweet-spot-in-the-public-sector-)
 
 General How-To Guides with Emphasis on Creating and Managing Your Own Open Source or Open Data Project 
-- The [Standard for Public Code](https://standard.publiccode.net), listed as a DPG itself, "gives public organizations a model for building their own open source solutions to enable successful future reuse by similar public organizations in other places. It includes guidance for policy makers, city administrators, developers and vendors."
 
-- [Federal Source Code Toolkit](https://github.com/GSA/code-gov-open-source-toolkit): This is a government-wide project facilitated by the Code.gov team to produce "how to" documentation pertaining to federal source code and open source software (OSS). It provides guidance to agencies for creating and maintaining federal source code inventories and open source repositories.
+* The [Standard for Public Code](https://standard.publiccode.net),
+  listed as a DPG itself, "gives public organizations a model for
+  building their own open source solutions to enable successful future
+  reuse by similar public organizations in other places. It includes
+  guidance for policy makers, city administrators, developers and
+  vendors."
 
-- RedHat's [Guidebook for open source community management: The Open Source Way 2.0](https://www.redhat.com/en/blog/guidebook-open-source-community-management-open-source-way-20). The Mozilla Foundation also created an [Open Leadership Training Series](https://mozilla.github.io/open-leadership-training-series/articles/building-communities-of-contributors/) that includes some useful tips on building contributor communities. 
+* [Federal Source Code
+  Toolkit](https://github.com/GSA/code-gov-open-source-toolkit): This
+  is a government-wide project facilitated by the Code.gov team to
+  produce "how to" documentation pertaining to federal source code and
+  open source software (OSS). It provides guidance to agencies for
+  creating and maintaining federal source code inventories and open
+  source repositories.
 
-- Unfortunately, participants in online communities exhibit the same destructive behavior we see in the real world, and marginalized, vulnerable community members are most frequently targeted. Clear community participation guidelines can help fend off some of these behaviors, and their *enforcement* builds trust within a community. [Mozilla's Community Participation Guideline (CPG)]( https://www.mozilla.org/en-US/about/governance/policies/participation/) is a great model to consider copying for your own open source project. Mozilla's CPG is based on existing best practices and a good amount of hands-on experience and research into creating more inclusive contributor communities. Note that it includes a clear structure for reporting problematic community behavior and what to expect as part of this process. The DPG OpenMRS has a good [code of conduct]( https://wiki.openmrs.org/display/RES/OpenMRS+Code+of+Conduct) that they adapted from the Ubuntu open source project. [Mozilla's 2020 analysis of its contributor communities](https://report.mozilla.community/assets/report/Mozilla-Rebel-Alliance-Report-2020.pdf) provides more insight into how to support diversity and inclusion.
+* RedHat's [Guidebook for open source community management: The Open
+  Source Way
+  2.0](https://www.redhat.com/en/blog/guidebook-open-source-community-management-open-source-way-20). The
+  Mozilla Foundation also created an [Open Leadership Training
+  Series](https://mozilla.github.io/open-leadership-training-series/articles/building-communities-of-contributors/)
+  that includes some useful tips on building contributor communities.
 
-https://producingoss.com/en/index.html
+* Unfortunately, participants in online communities exhibit the same
+  destructive behavior we see in the real world, and marginalized,
+  vulnerable community members are most frequently targeted. Clear
+  community participation guidelines can help fend off some of these
+  behaviors, and their *enforcement* builds trust within a
+  community. [Mozilla's Community Participation Guideline (CPG)](
+  https://www.mozilla.org/en-US/about/governance/policies/participation/)
+  is a great model to consider copying for your own open source
+  project. Mozilla's CPG is based on existing best practices and a
+  good amount of hands-on experience and research into creating more
+  inclusive contributor communities. Note that it includes a clear
+  structure for reporting problematic community behavior and what to
+  expect as part of this process. The DPG OpenMRS has a good [code of
+  conduct](
+  https://wiki.openmrs.org/display/RES/OpenMRS+Code+of+Conduct) that
+  they adapted from the Ubuntu open source project. [Mozilla's 2020
+  analysis of its contributor
+  communities](https://report.mozilla.community/assets/report/Mozilla-Rebel-Alliance-Report-2020.pdf)
+  provides more insight into how to support diversity and inclusion.
 
-https://opensource.guide/leadership-and-governance/
+* https://producingoss.com/en/index.html
 
-Crowdsourcing data collection -- particularly through volunteers -- can also require attention to community development and management (e.g. [Lacuna Fund's RFP requirements here](https://s31207.pcdn.co/wp-content/uploads/sites/11/2020/09/RFP-Language_23-Sept-1.pdf)). 
+* https://opensource.guide/leadership-and-governance/
 
-The open source and open data project Common Voice [published a ['community playbook'](https://common-voice.github.io/community-playbook/)to foster new, independent communities to form around collecting voice data different languages. This guidance helps Mozilla track data collection around the globe and ensure high quality while letting local efforts grow without much centralized control. 
+* Crowdsourcing data collection -- particularly through volunteers --
+  can also require attention to community development and management
+  (e.g. [Lacuna Fund's RFP requirements
+  here](https://s31207.pcdn.co/wp-content/uploads/sites/11/2020/09/RFP-Language_23-Sept-1.pdf)). 
 
-However, don't be put off by the more thorough guides we cite above and feel encouraging and managing an open source project requires significant investment in community development and governance. Deep investment isn't necessary for every project type. For those where it makes sense, you should approach community development in phases and 'right size' investment to what's needed. For example, the DPG [AI Agro's machine learning algorithms](https://github.com/RentadroneCL/AI-Agro) are available on GitHub, with a simple overview of their project on  that makes it clear what they plan to work on, how to contribute, and how to join the community discussion on Discourse. If we had to peg this as an archetype, it's probably most akin to a Speciality Library. They're open to anyone participating, but they're likely to only attract those who have the skills and expertise to contribute and don't need to build for a broader audience. The DPG Primero created a [global inter-agency governance structure](https://www.unicef.org/evaluation/media/946/file/Primero.pdf) only when the platform had matured enough to merit such formalized oversight. 
+* The open source and open data project Common Voice [published a
+  ['community
+  playbook'](https://common-voice.github.io/community-playbook/)to
+  foster new, independent communities to form around collecting voice
+  data different languages. This guidance helps Mozilla track data
+  collection around the globe and ensure high quality while letting
+  local efforts grow without much centralized control.
 
-For those projects that would benefit from a community manager, note that a community manager's role can be more broadly defined to include adjacent work like documentation, running trainings, and managing key partners, as well as typical community management tasks like   . For an example, see a [recent job posting for a community managaer](https://www.kobotoolbox.org/join-our-team/project-community-engagement-coordinator.html) from the the team behind the Kobo Toolbox DPG (accessed Sept. 2021). 
+However, don't be put off by the more thorough guides we cite above
+and feel encouraging and managing an open source project requires
+significant investment in community development and governance. Deep
+investment isn't necessary for every project type. For those where it
+makes sense, you should approach community development in phases and
+'right size' investment to what's needed. For example, the DPG [AI
+Agro's machine learning
+algorithms](https://github.com/RentadroneCL/AI-Agro) are available on
+GitHub, with a simple overview of their project on that makes it clear
+what they plan to work on, how to contribute, and how to join the
+community discussion on Discourse. If we had to peg this as an
+archetype, it's probably most akin to a Speciality Library. They're
+open to anyone participating, but they're likely to only attract those
+who have the skills and expertise to contribute and don't need to
+build for a broader audience. The DPG Primero created a [global
+inter-agency governance
+structure](https://www.unicef.org/evaluation/media/946/file/Primero.pdf)
+only when the platform had matured enough to merit such formalized
+oversight.
 
-
-
- 
-
+For those projects that would benefit from a community manager, note
+that a community manager's role can be more broadly defined to include
+adjacent work like documentation, running trainings, and managing key
+partners, as well as typical community management tasks like . For an
+example, see a [recent job posting for a community
+managaer](https://www.kobotoolbox.org/join-our-team/project-community-engagement-coordinator.html)
+from the the team behind the Kobo Toolbox DPG (accessed Sept. 2021).
 
 ## **COMMUNITY** 
-This [2018 slide presentation of project archetypes](https://opentechstrategies.com/files/presentations/2018-finos/finos-presentation.html) is a useful short summary. 
 
-Health- https://producingoss.com/en/evaluating-oss-projects.html
+This [2018 slide presentation of project
+archetypes](https://opentechstrategies.com/files/presentations/2018-finos/finos-presentation.html)
+is a useful short summary.
 
-Mozilla's https://report.mozilla.community/
+Health: https://producingoss.com/en/evaluating-oss-projects.html
+
+Mozilla: https://report.mozilla.community/
 
 Creating your own community
-There's a rich set of online materials about how to create and nurture a thriving open source community. Some of our favorites include: 
-- [Producing Open Source Software: How to Run a Successful Free Software Project](https://producingoss.com/en/index.html) Karl Fogel
 
-- The EU's [Guidelines for Sustainable Open Source Communities in the Public Sector](https://joinup.ec.europa.eu/sites/default/files/inline-files/Guidelines%20for%20Sustainable%20OSS%20Communities%20in%20the%20Public%20Sector%20final.pdf) (2020). This aligns with the recommendations covered here, from a needs and readiness assessment through long term sustainability, but it also includes a lits of key considerations to building your own open source community. 
+There's a rich set of online materials about how to create and nurture
+a thriving open source community. Some of our favorites include:
 
-- The TODO Group's [Starting an Open Source Project](https://todogroup.org/guides/starting/) and [Building an Inclusive Open Source Community](https://todogroup.org/guides/diversity-inclusion/)
+* The EU's [Guidelines for Sustainable Open Source Communities in the
+  Public
+  Sector](https://joinup.ec.europa.eu/sites/default/files/inline-files/Guidelines%20for%20Sustainable%20OSS%20Communities%20in%20the%20Public%20Sector%20final.pdf)
+  (2020). This aligns with the recommendations covered here, from a
+  needs and readiness assessment through long term sustainability, but
+  it also includes a lits of key considerations to building your own
+  open source community.
 
-https://opensource.guide/building-community/
-producingoss
+* The TODO Group's [Starting an Open Source
+  Project](https://todogroup.org/guides/starting/) and [Building an
+  Inclusive Open Source
+  Community](https://todogroup.org/guides/diversity-inclusion/)
 
-https://www.contributor-covenant.org/
+* https://opensource.guide/building-community/
 
-The OpenSRP project publishes a very readable, straightforward [overview of how its governance, contribution process and community management work](https://smartregister.org/governance-structure/). 
+* https://www.contributor-covenant.org/
 
-Regarding external financing of projects, the [Guidelines for Funding Open Source Software Development](https://www.archesproject.org/wp-content/uploads/2018/01/guidelines_funding_OSS.pdf]) was written with an audience of public and private foundations in mind and will give you a good sense of what many funders are likely to look for in a proposal that includes open source software development. Many of the points in these guidelines also show up in practical recommendations in this paper, but you might still benefit from glancing at this as you plan for your DPG. 
+* The OpenSRP project publishes a very readable, straightforward
+  [overview of how its governance, contribution process and community
+  management work](https://smartregister.org/governance-structure/). 
 
-Code of conduct - https://wiki.openmrs.org/display/RES/OpenMRS+Code+of+Conduct
+* [Producing Open Source Software: How to Run a Successful Free
+  Software Project](https://producingoss.com/en/index.html)
 
+* Regarding external financing of projects, the [Guidelines for
+  Funding Open Source Software
+  Development](https://www.archesproject.org/wp-content/uploads/2018/01/guidelines_funding_OSS.pdf])
+  was written with an audience of public and private foundations in
+  mind and will give you a good sense of what many funders are likely
+  to look for in a proposal that includes open source software
+  development. Many of the points in these guidelines also show up in
+  practical recommendations in this paper, but you might still benefit
+  from glancing at this as you plan for your DPG.
 
+* Code of conduct - https://wiki.openmrs.org/display/RES/OpenMRS+Code+of+Conduct
 
 ## **POLICY**
 
 **Integrated Policy Approaches**
 
 The World Bank pubished a background paper [Estonian e-Government
-Ecosystem: Foundation, Applications, Outcomes](https://thedocs.worldbank.org/en/doc/165711456838073531-0050022016/original/WDR16BPEstonianeGovecosystemVassil.pdf) that's a thorough overview of the integrated factors -- policies, institutions, technologies and more -- that helped Estonia create a successful e-government service ecosystem. 
+Ecosystem: Foundation, Applications,
+Outcomes](https://thedocs.worldbank.org/en/doc/165711456838073531-0050022016/original/WDR16BPEstonianeGovecosystemVassil.pdf)
+that's a thorough overview of the integrated factors -- policies,
+institutions, technologies and more -- that helped Estonia create a
+successful e-government service ecosystem.
 
 **Public Domain**
-The Open Source Initiative provides a simple explanation of the [problems of public domain software](https://opensource.org/faq#public-domain)
+
+The Open Source Initiative provides a simple explanation of the
+[problems of public domain
+software](https://opensource.org/faq#public-domain)
 
 **Security**
-We like David Wheeler's much noted [essay on security in open source versus closed source](https://dwheeler.com/secure-programs/Secure-Programs-HOWTO/open-source-security.html). Bruce Schneier, a renouned security expert, has also [written frequently on the topic](https://www.schneier.com/blog/archives/2020/12/open-source-does-not-equal-secure.html) 
 
-The Open Source Security Foundation publishes[free EdX courses](https://openssf.org/edx-courses) on best practices in developing secure software and hosts a [related open community](https://github.com/ossf/wg-best-practices-os-developer). The paper [Threats, Risks, and Mitigations in the Open Source Ecosystem](https://github.com/ossf/wg-identifying-security-threats/blob/main/publications/threats-risks-mitigations/v1.1/Threats%2C%20Risks%2C%20and%20Mitigations%20in%20the%20Open%20Source%20Ecosystem%20-%20v1.1.pdf) has a great overview of how to think about security from the perspective of an open source ecosystem (here, they use ecosystem to describe the set of things that comprise a specific open source project, such as developers, end users, technical architecture, and package libraries).
+We like David Wheeler's much noted [essay on security in open source
+versus closed
+source](https://dwheeler.com/secure-programs/Secure-Programs-HOWTO/open-source-security.html).
+Bruce Schneier, a renouned security expert, has also [written
+frequently on the
+topic](https://www.schneier.com/blog/archives/2020/12/open-source-does-not-equal-secure.html).
 
-Similar to the Principles for Digital Development on Privacy and Security](https://digitalprinciples.org/principle/address-privacy-security/), the Open Reference Architecture for Security and Privacy lists its own set of [key principles](https://security-and-privacy-reference-architecture.readthedocs.io/en/latest/08-security-principles.html) along with a list of FOSS security and privacy applications.(https://security-and-privacy-reference-architecture.readthedocs.io/en/latest/security-sbbs.html)
+The Open Source Security Foundation publishes[free EdX
+courses](https://openssf.org/edx-courses) on best practices in
+developing secure software and hosts a [related open
+community](https://github.com/ossf/wg-best-practices-os-developer). The
+paper [Threats, Risks, and Mitigations in the Open Source
+Ecosystem](https://github.com/ossf/wg-identifying-security-threats/blob/main/publications/threats-risks-mitigations/v1.1/Threats%2C%20Risks%2C%20and%20Mitigations%20in%20the%20Open%20Source%20Ecosystem%20-%20v1.1.pdf)
+has a great overview of how to think about security from the
+perspective of an open source ecosystem (here, they use ecosystem to
+describe the set of things that comprise a specific open source
+project, such as developers, end users, technical architecture, and
+package libraries).
+
+Similar to the Principles for Digital Development on Privacy and
+Security](https://digitalprinciples.org/principle/address-privacy-security/),
+the Open Reference Architecture for Security and Privacy lists its own
+set of [key
+principles](https://security-and-privacy-reference-architecture.readthedocs.io/en/latest/08-security-principles.html)
+along with a list of FOSS security and privacy
+applications.(https://security-and-privacy-reference-architecture.readthedocs.io/en/latest/security-sbbs.html)
 
 A few **security questionnaires** we've come across that you might find useful as you evaluate working with vendors include: 
-- [This security questionnaire](https://www.nj.gov/labor/assets/PDFs/rfq/SoNJ%20Third-Party%20Information%20Security%20Questionnaire%20v1.0.pdf) is from the state of New Jersey in the United States. It's extremely comprehensive and does reference local and national laws in the United States, yet it's still a useful model. 
-- [Google publishes several security questionnaires](https://vsaq-demo.withgoogle.com) that are also supported by an adaptable [interactive questionnaire application](https://github.com/google/vsaq)
 
-The United States National Institute for Standards and Techology (NIST) publishes a [security testing technical guide](https://www.nist.gov/publications/technical-guide-information-security-testing-and-assessment) that gives an "overview of key elements of technical security testing and examination, with an emphasis on specific technical techniques, the benefits and limitations of each, and recommendations for their use."
+- [This security
+  questionnaire](https://www.nj.gov/labor/assets/PDFs/rfq/SoNJ%20Third-Party%20Information%20Security%20Questionnaire%20v1.0.pdf)
+  is from the state of New Jersey in the United States. It's extremely
+  comprehensive and does reference local and national laws in the
+  United States, yet it's still a useful model.
 
-The [SAFETAG](https://safetag.org) is a security auditing framework and evaluation template aimed at advocacy groups that might be more ‘right sized’ for capacity limited DPGs.
+- [Google publishes several security
+  questionnaires](https://vsaq-demo.withgoogle.com) that are also
+  supported by an adaptable [interactive questionnaire
+  application](https://github.com/google/vsaq)
 
+* The United States National Institute for Standards and Techology
+  (NIST) publishes a [security testing technical
+  guide](https://www.nist.gov/publications/technical-guide-information-security-testing-and-assessment)
+  that gives an "overview of key elements of technical security
+  testing and examination, with an emphasis on specific technical
+  techniques, the benefits and limitations of each, and
+  recommendations for their use."
+
+* The [SAFETAG](https://safetag.org) is a security auditing framework
+  and evaluation template aimed at advocacy groups that might be more
+  'right sized' for capacity limited DPGs.
 
 Lastly, some thoughts on **cultural and security considerations when coding in the open**. 
 
-It’s important to think through the
-cultural shifts required for an open project to succeed. Regulation, policies and processes can set the boundaries of
-an environment and influence behaviour, but the execution is still up
-to individual human choice. 
+It's important to think through the cultural shifts required for an
+open project to succeed. Regulation, policies and processes can set
+the boundaries of an environment and influence behaviour, but the
+execution is still up to individual human choice.
 
 Open source co-development often requires new tools and processes, and
-that change must be supported by the organization’s culture. At its
+that change must be supported by the organization's culture. At its
 heart, open source collaboration requires communicating and coding in
 the open. This transparency brings the benefits outlined throughout
 this document, but it also opens the project -- and its human
-participants -- to feeling vulnerable to more criticism and being called out more easily for mistakes. Recognize
-that change feels like a loss to many. It feels like a loss of stability and what they knew about how to work, and they will need leadership and guidance. Be sure to keep conversations going in your team about how well organizational culture supports their needs. 
+participants -- to feeling vulnerable to more criticism and being
+called out more easily for mistakes. Recognize that change feels like
+a loss to many. It feels like a loss of stability and what they knew
+about how to work, and they will need leadership and guidance. Be sure
+to keep conversations going in your team about how well organizational
+culture supports their needs.
 
-One of the greatest fears of many developers is to jeopardize a project’s security
-and potentially harm real people. Many might worry that open source
-code is itself a security vulnerability. What if a mistake is made in the open? How can an
-agency decide what code should stay proprietary because of security
-concerns? 
+One of the greatest fears of many developers is to jeopardize a
+project's security and potentially harm real people. Many might worry
+that open source code is itself a security vulnerability. What if a
+mistake is made in the open? How can an agency decide what code should
+stay proprietary because of security concerns?
 
 The UK government has publicly wrangled with these issues and come up
-with useful guidance. It’s notable that their stance on how much code
-to develop through an open source model has changed from “most” to
-“all, with very limited exceptions.” In short, their experience taught
+with useful guidance. It's notable that their stance on how much code
+to develop through an open source model has changed from "most" to
+"all, with very limited exceptions."  In short, their experience taught
 them that open sourcing code was actually a great way to confirm and
 enhance security, perhaps even particularly for code related to
 managing security. When following and enforcing [strong security
@@ -139,7 +299,7 @@ design](https://www.ncsc.gov.uk/collection/cyber-security-design-principles),
 such as ensuring configuration files are kept separately from code,
 they found that open peer review improves security. 
 
-The UK’s guidance [Security Considerations When Coding in the
+The UK's guidance [Security Considerations When Coding in the
 Open](https://www.gov.uk/government/publications/open-source-guidance/security-considerations-when-coding-in-the-open)
 is a concise, clear checklist for developers and program managers that
 links to other useful resources, such as how to manage software
@@ -147,13 +307,15 @@ dependencies and the value of automated style enforcement. These
 checklist items include:
 
 * Open the code early
-* Don’t rely on closed code as your only security measure
+* Don't rely on closed code as your only security measure
 * Follow good development practices
 * Keep keys and credentials closed
 * Assume accidental publications are compromised
 * Deal with security vulnerabilities
 
-Their [approach to when code should be kept closed](https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed) is similarly straightforward:
+Their [approach to when code should be kept
+closed](https://www.gov.uk/government/publications/open-source-guidance/when-code-should-be-open-or-closed)
+is similarly straightforward:
 
 * Data and code related to keys and credentials
 * Algorithms used to detect fraud
@@ -162,21 +324,40 @@ Their [approach to when code should be kept closed](https://www.gov.uk/governmen
 
 ## **ADOPTABILITY**
 
-The [Open Source Maturity Model](https://en.wikipedia.org/wiki/OpenSource_Maturity_Model) is another way of evaluating an open source product for adoption. It covers the same points we review in the paper, but it has more of a process-oriented approach that also includes scoring and weighting. More background is in this article by Bernard Golden in [Technology Innovation Management Review](https://timreview.ca/article/145), (May 2008).
+The [Open Source Maturity
+Model](https://en.wikipedia.org/wiki/OpenSource_Maturity_Model) is
+another way of evaluating an open source product for adoption. It
+covers the same points we review in the paper, but it has more of a
+process-oriented approach that also includes scoring and
+weighting. More background is in this article by Bernard Golden in
+[Technology Innovation Management
+Review](https://timreview.ca/article/145), (May 2008).
 
 
 ## **PROCUREMENT**
 
-The Digital Impact Alliance's [Procurement Of Digital Technology](https://procurement-digitalimpactalliance.org/) is a useful guide for budget planning. [TODO: describe a bit better w/ context] [NEW TODO: To delete b/c it's now incorporated into main text appropriately]
+The Digital Impact Alliance's [Procurement Of Digital
+Technology](https://procurement-digitalimpactalliance.org/) is a
+useful guide for budget planning. [TODO: describe a bit better w/
+context] [NEW TODO: To delete b/c it's now incorporated into main text
+appropriately]
 
-This [panel discussion about agile development and modular contracts](https://www.agilegovleaders.org/watch-agl-live-wild-wild-west-managing-agile-contracts-in-government/) includes public sector employees from the state of California and 18F, discussing great insights about the challenges and lessons learned in their revamp of California's Child Welfare digital system.
+This [panel discussion about agile development and modular
+contracts](https://www.agilegovleaders.org/watch-agl-live-wild-wild-west-managing-agile-contracts-in-government/)
+includes public sector employees from the state of California and 18F,
+discussing great insights about the challenges and lessons learned in
+their revamp of California's Child Welfare digital system.
 
 (TBD: [ref:f9f71f8d]: Let's break out this long procurement-language
 example into a separate appendix.  That thought might apply to other
 sections in this appendix, too, but it applies most strongly here I
 think.  -Karl)
 
-Useful sample contract language [TODO: do we have better on hand? We don't have explicit permssion to use the following, although I can ask. Below is also US centric. https://www.eckertseamans.com/app/uploads/Steve-Foxman_Eckert-Seamans_DATA-PROTECTION-CLAUSES-101016-M1566466xA35AF.pdf ]
+Useful sample contract language
+
+(TODO: Do we have better on hand?  We are asking for permssion to use
+the following, but it's still US-centric.
+https://www.eckertseamans.com/app/uploads/Steve-Foxman_Eckert-Seamans_DATA-PROTECTION-CLAUSES-101016-M1566466xA35AF.pdf)
 
 Disclaimer: The following clauses are examples of actual data protection clauses used in technology agreements, adapted to remove any identifying information regarding the providers or customers. Use and final language of the following clauses must be modified to be appropriate for any specific software or service being provided by a licensor, vendor or service provider. Such clauses should not be used without advice from a lawyer familiar with technology agreements and data protection issues. Close attention must also be paid to any disclaimer or limitation of liability clauses, which may undermine the effectiveness of remedies related to any breach by any licensor, vendor or service provider of its contractual obligations.
 

--- a/appendix-resources-tools.md
+++ b/appendix-resources-tools.md
@@ -167,14 +167,16 @@ The [Open Source Maturity Model](https://en.wikipedia.org/wiki/OpenSource_Maturi
 
 ## **PROCUREMENT**
 
-The Digital Impact Alliance's [Procurement Of Digital Technology](https://procurement-digitalimpactalliance.org/) is a useful guide for budget planning. [TODO: describe a bit better w/ context]
+The Digital Impact Alliance's [Procurement Of Digital Technology](https://procurement-digitalimpactalliance.org/) is a useful guide for budget planning. [TODO: describe a bit better w/ context] [NEW TODO: To delete b/c it's now incorporated into main text appropriately]
+
+This [panel discussion about agile development and modular contracts](https://www.agilegovleaders.org/watch-agl-live-wild-wild-west-managing-agile-contracts-in-government/) includes public sector employees from the state of California and 18F, discussing great insights about the challenges and lessons learned in their revamp of California's Child Welfare digital system.
 
 (TBD: [ref:f9f71f8d]: Let's break out this long procurement-language
 example into a separate appendix.  That thought might apply to other
 sections in this appendix, too, but it applies most strongly here I
 think.  -Karl)
 
-Useful sample contract language [TODO: do we have better on hand? We don't have explicit permssion to use the following, although I can ask. Below is also us centric. https://www.eckertseamans.com/app/uploads/Steve-Foxman_Eckert-Seamans_DATA-PROTECTION-CLAUSES-101016-M1566466xA35AF.pdf ]
+Useful sample contract language [TODO: do we have better on hand? We don't have explicit permssion to use the following, although I can ask. Below is also US centric. https://www.eckertseamans.com/app/uploads/Steve-Foxman_Eckert-Seamans_DATA-PROTECTION-CLAUSES-101016-M1566466xA35AF.pdf ]
 
 Disclaimer: The following clauses are examples of actual data protection clauses used in technology agreements, adapted to remove any identifying information regarding the providers or customers. Use and final language of the following clauses must be modified to be appropriate for any specific software or service being provided by a licensor, vendor or service provider. Such clauses should not be used without advice from a lawyer familiar with technology agreements and data protection issues. Close attention must also be paid to any disclaimer or limitation of liability clauses, which may undermine the effectiveness of remedies related to any breach by any licensor, vendor or service provider of its contractual obligations.
 

--- a/community.md
+++ b/community.md
@@ -1,14 +1,15 @@
 # Community And Ecosystem
 
 **KEY RECOMMENDATION**: Communities and ecosystems around open source
-projects are not all the same. Their differences matter in setting
-correct expectations around likely project dynamics, health, and
-sustainability. With an ecosystem map as background, consider what
-project archetype might roughly fit the open source project you're
-evaluating or that you plan to launch. Although these maps are inexact
-approximations that change over time, this is a key level-setting
-exercise for your team when assessing an open source project or
-planning to create your own, and it should be periodically revisited.
+projects are not all the same. Project archetypes describe these differences and can help you understand a project's dynamics, health, and
+sustainability. This is useful when assessing an open source project for adoption or
+in creating your own open source project. These insights can help you set expections and plan investments. 
+
+EXAMPLE: The City of Paris'
+  [Lutece](https://lutece.paris.fr/lutece/), an open source platform
+  for municipal digital services, largely aligns with the Controlled Ecosystem archetype, in which a 'benevolent dictator' (here, the City of Paris) manages the core platform that 
+ supports over [400 customized plugins created by cities and organizations
+  accross the globe](https://lutece.paris.fr/lutece/community.html). A team considering adopting Lutece and working with a vendor to create several specific extensions wouldn't worry if the vendor hasn't contributed to the main platform but would look for contribution to several existing extensions as a sign of experience and competence.
 
 **KEY RECOMMENDATION** Diversity among participants making the most
 resource investments in an open source project indicates stability,
@@ -17,41 +18,33 @@ diversity in areas like employers of contributors or of vendors
 providing support services, such as customization, deployment
 assistance, maintenance and operations, and training.
 
-**KEY RECOMMENDATION**: To roughly assess the health of an open source
-project, look at the bug tracker to understand the activity 'vibrancy'
-around the project. The bug tracker, along with other web resources
-like user forums, should also give you some insight into the diversity
-of developers and commercial participants. Diversity, the growth rate
-of adoption, and a well structured ability to respond to input are
-good markers of health and sustainability. The level of quality
-community 'scaffolding' around a project, such as documentation,
-should also fit what you'd expect for that project's type. And lastly,
-talking to a sample of diverse participants will also give you as
-sense for how the community is doing.
+EXAMPLE: [55 commerical businesses](https://mifos.org/directory) provide a broad array of supporting services around the financial inclusion DPG [Mifos](https://mifos.org/), from custom development and hosting to business consulting and deployment support. 
+
+[TODO: MIFOS has a lot of partners but I don't see a lot of this showing up in the public repo. I quickly looked at dev forum mailing list and it seems pretty diverse, so I think the above is fair enough to say. Not sure if an example comes to someone else's mind? Mifos web site also says they have a marketplace/app store but I couldn't find a link or other reference online...]
 
 **KEY RECOMMENDATION**: Encouraging commercial participation can be
 useful to a DPG's adoption and sustainability, but take care to foster
 diverse commercial actors and be wary of creating commerical
 opportunities that could permit unfair advantage.
 
-**KEY RECOMMENDATION**: A 'hard fork' of a project to meet your needs
-should always be a last resort. Such an action might be appropriate
-for a mature open source product in which there is community
-understanding of and support for your new direction, but this is a
-costly and fraught thing to do and would require thorough planning and
-much foresight.
+EXAMPLE: The DPG [Mojaloop](https://mojaloop.io/) publishes a [list](https://mojaloop.io/mojaloop-business-directory) of consultants, systems integrators,
+training organizations, business operations supporters and other
+solution providers, vetted against a published list of criteria. They also [host open training,
+networking, and business development
+events](https://mojaloop.io/category/events/) to connect these commerical participants to new business opportunities. 
 
-**KEY RECOMMENDATION**: For you own DPG, consider how you might
-approach financial sustainability differently across the project's
-stages. Monolithic funding isn't necessarily the answer. The types and
-sources of available funding options might change as a project
+**KEY RECOMMENDATION**: Financial sustainability can look different across a project's
+stages. The types and sources of available funding options might change as a project
 progresses.
 
-**KEY RECOMMENDATION**: For you own DPG, consider how you might
-approach financial sustainability differently across the project's
-stages. Monolithic funding isn't necessarily the answer. The types and
-sources of available funding options might change as a project
-progresses.
+EXAMPLE: Your agency might be able to cover seed funding, as was the case with the World Bank's Global Facility for Disaster Reduction and Recovery (GFDDR) with the [GeoNode project](https://geonode.org/). Philanthropic funds might help you pilot the project in particular locations, as was the case with the
+[DHIS2](https://dhis2.org/), or to scale, as was the case with
+[OpenSRP](https://wiki.digitalsquare.io/index.php/Digital_Square_Investments_in_Global_Goods#Notice_B_Investments). Charging for use might cover ongoing maintenance costs. For example, the DPG [ODK](https://getodk.org/) is free as a self-hosted solution for
+offline data collection, but the organization also provides [cloud-based hosting at different pricing
+tiers](https://getodk.org/#odk-cloud). 
+
+
+
 
 Understanding how to work with, participate in, and foster a
 successful open source project is not just a matter of understanding
@@ -232,7 +225,7 @@ available).
   own separate but duplicative solution.  For
   example:[Kubernetes](https://kubernetes.io/), an open-source system
   for automating deployment, scaling, and management of containerized
-  applications. [X-Road's distributed data
+  applications. [X-Road's(™) distributed data
   exchange](https://x-road.global/x-road-technology-overview) is a DPG
   example here as well.
 
@@ -298,7 +291,7 @@ available).
   [Lutece](https://lutece.paris.fr/lutece/), an open source platform
   for municipal digital services, is a controlled ecosystem project
   that supports over 400 plugins created by cities and organizations
-  accross the globe.  Estonia's DPG X-road (now managed by the Nordic
+  accross the globe.  Estonia's DPG X-Road(™) (now managed by the Nordic
   Institute for Interoperability Solutions (NIIS)) fits here, with its
   [support for
   extensions](https://x-road.global/xroad-technology-partners-companies),
@@ -430,7 +423,9 @@ conversation should never end there.
 **KEY RECOMMENDATION**: Communities and ecosystems around open source
 projects are not all the same. Their differences matter in setting
 correct expectations around likely project dynamics, health, and
-sustainability. With an ecosystem map as background, consider what
+sustainability. 
+
+With an ecosystem map as background, consider what
 project archetype might roughly fit the open source project you're
 evaluating or that you plan to launch. Although these maps are inexact
 approximations that change over time, this is a key level-setting
@@ -442,7 +437,7 @@ long, so let's leave off for the moment and not go deeper than we
 need.  Note: Victor
 [suggests](https://github.com/unicef/publicgoods-toolkit/pull/12#discussion_r651325121)
 including a mapping/analysis of some existing DPGs to the archetypes.
-We can add that analysis after doing some interviews.)
+We can add that analysis after doing some interviews.)<-- SUSY NOTE: some DPG examples added above>
 
 ## Community Diversity
 
@@ -467,7 +462,7 @@ services -- simply because these aspects of diversity are so often
 overlooked, and yet are so important to the health and success of a
 DPG.  This diversity is particularly important to projects that aren't
 speciality software libraries, although even there overreliance on one
-contributor type can be problematic.
+contributor type can be problematic. Note that it can take some sleuthing to figure out the backgrounds of contributors, who often use a non-work related identifier or even pseudonyms. 
 
 In considering diversity, including diversity of investment sources,
 it is useful to recall that participants tend to exercise control over
@@ -492,7 +487,7 @@ attract new participants.
 **FURTHER READING** The World Bank's [Open Data for Resilience
 Initiative + GeoNode: A Case Study on Institutional Investments in
 Open
-Source](https://opendri.org/wp-content/uploads/2017/03/OpenDRI-and-GeoNode-a-Case-Study-on-Institutional-Investments-in-Open-Source.pdf)presents
+Source](https://opendri.org/wp-content/uploads/2017/03/OpenDRI-and-GeoNode-a-Case-Study-on-Institutional-Investments-in-Open-Source.pdf) presents
 how the Global Facility for Disaster Reduction and Recovery (GFDRR)
 invested in a diversified set of partners, in part by using modular
 contracting (see also Procurement), ultimately creating a successfully
@@ -613,7 +608,7 @@ reporting) that you'd expect for such a project type and its maturity.
 Second, actually speaking to a variety of people involved in the
 project almost always leads to valuable insights.
 
-**KEY RECOMMENDATION**: To roughly assess the health of an open source
+**RECOMMENDATION**: To roughly assess the health of an open source
 project, look at the bug tracker to understand the activity 'vibrancy'
 around the project.  The bug tracker, along with other web resources
 like user forums, should also give you some insight into the diversity
@@ -771,12 +766,11 @@ business.
 Some DPG projects go even a step further.  As a way to spur further
 investment by commercial participants, they undertake to create
 commercial opportunities for participants.  For example, the [DPG
-Mojaloop publishes a vetted list of consultants, systems integrators,
+Mojaloop publishes a list of consultants, systems integrators,
 training organizations, business operations supporters and other
-solution providers](https://mojaloop.io/mojaloop-business-directory),
-connecting them to new business opportunities, and [hosts training,
+solution providers](https://mojaloop.io/mojaloop-business-directory), vetted against a published list of criteria. They also [host open training,
 networking, and business development
-events](https://mojaloop.io/category/events/).  Sometimes these
+events](https://mojaloop.io/category/events/) to connect these commerical participants to new business opportunities. Sometimes these
 opportunities tend to reward more active project participants.  So
 long as these opportunities do not start to create monopolizable
 advantages, they can be effective ways to promote sustainability for
@@ -784,7 +778,7 @@ some DPG efforts.  A review of an open source project's governance
 documents, if available, can give you some additional sense of how
 well commercial engagement is steered towards the collective good.
 
-The Mifos Initiative knew they not only had to engage existing banking
+The Mifos initiative knew they not only had to engage existing banking
 institutions to drive product adoption, but they also had to create
 opportunities for new, innovative, local companies that could deliver
 the 'last mile' for financial inclusion.  A centralized, proprietary
@@ -799,7 +793,7 @@ also invested early in developing [local IT
 partnerships](https://mifos.org/mifos-initiative/partner-led-ecosystem-2/)
 to help with implementating, hosting, and supporting Mifos X.
 Moreover, they turned users into active agents for innovation and
-adoption by establishing[community
+adoption by establishing [community
 chapters](https://mifos.org/resources/community/mifos-chapters/).
 These local volunteer organizations help communities use and shape
 Mifos to their particular needs, and they provide feedback to the main
@@ -876,7 +870,7 @@ an agency's needs, it might be reasonable to consider a hard fork, and
 you might find the project's community supportive of your new
 direction.
 
-**KEY RECOMMENDATION**: A 'hard fork' of a project to meet your needs
+**RECOMMENDATION**: A 'hard fork' of a project to meet your needs
 should always be a last resort. Such an action might be appropriate
 for a mature open source product in which there is community
 understanding of and support for your new direction, but this is a
@@ -987,6 +981,7 @@ approaches.
  
 (TBD: from Karl: I'm not sure that all these named quotes are what we
 want.  Will check with UNICEF about this.)
+(SUSY: Totally understood. There's not a lot of good case study examples to support some of our points, so I turned to quotes from the interviews where I thought they could bring in the experiential insight)
 
 George Gelaga-King spoke of how pooling financial and personnel
 resources across agencies to create a DPG is also an option, although
@@ -1003,7 +998,7 @@ digital services agencies are often at the forefront of government
 digital transformation.
  
 [Social impact
-bonds](https://www.oecd.org/cfe/leed/SIBs-State-Play-Lessons-Final.pdf)(also
+bonds](https://www.oecd.org/cfe/leed/SIBs-State-Play-Lessons-Final.pdf) (also
 known as development impact bonds) are another method of bringing
 private capital to the creation and maintenance of public goods. By
 definition, they seem like they would help bring more funding to the
@@ -1040,7 +1035,7 @@ here.
 Lastly, charging for use might be an option as well.  For example, the
 DPG [ODK](https://getodk.org/) is free as a self-hosted solution for
 offline data collection, but the organization also provides
-cloud-based hosting at different pricing
+[cloud-based hosting at different pricing
 tiers](https://getodk.org/#odk-cloud).  Infrastructural components of
 some DPGs might lend themselves to a revenue-generating model for
 commercial implementations to support free non-commercial
@@ -1057,7 +1052,7 @@ The most important take-away is to think about your DPG’s financial
 sustainability from a project lifecycle viewpoint.  Early design and
 feasibility work might be funded through research grants to a partner
 academic institute.  Seed funding might be at a low enough threshold
-for your agency to cover, as it was for GFDDR with GeoNode, or you
+for your agency to cover, as it was for the World Bank's Global Facility for Disaster Reduction and Recovery (GFDDR) with the GeoNode project, or you
 might complement your investment in an external vendor with funding
 from a social impact investor.  Philanthropic funds might help you
 pilot the project in particular locations, as was the case with the
@@ -1079,10 +1074,6 @@ Training and ongoing maintenance costs might be linked with existing
 investments or new grants to local academic institutions to improve
 digital skills and build the local workforce.
 
-(TBD: Mifos has an ROI evaluation framework and .xlsx that seems like
-it should be promising to look at, but it's not publicly accessible
-despite the link.
-https://mifos.org/blog/documenting-technology-impact-mifos-roi-model-case-studies/)
  
 **KEY RECOMMENDATION**: Consider how you might approach financial
 sustainability differently across your DPG's project

--- a/community.md
+++ b/community.md
@@ -1,15 +1,24 @@
 # Community And Ecosystem
 
 **KEY RECOMMENDATION**: Communities and ecosystems around open source
-projects are not all the same. Project archetypes describe these differences and can help you understand a project's dynamics, health, and
-sustainability. This is useful when assessing an open source project for adoption or
-in creating your own open source project. These insights can help you set expections and plan investments. 
+projects are not all the same. Project archetypes describe these
+differences and can help you understand a project's dynamics, health,
+and sustainability. This is useful when assessing an open source
+project for adoption or in creating your own open source
+project. These insights can help you set expections and plan
+investments.
 
-EXAMPLE: The City of Paris'
-  [Lutece](https://lutece.paris.fr/lutece/), an open source platform
-  for municipal digital services, largely aligns with the Controlled Ecosystem archetype, in which a 'benevolent dictator' (here, the City of Paris) manages the core platform that 
- supports over [400 customized plugins created by cities and organizations
-  accross the globe](https://lutece.paris.fr/lutece/community.html). A team considering adopting Lutece and working with a vendor to create several specific extensions wouldn't worry if the vendor hasn't contributed to the main platform but would look for contribution to several existing extensions as a sign of experience and competence.
+EXAMPLE: The City of Paris' [Lutece](https://lutece.paris.fr/lutece/),
+an open source platform for municipal digital services, largely aligns
+with the Controlled Ecosystem archetype, in which a 'benevolent
+dictator' (here, the City of Paris) manages the core platform that
+supports over [400 customized plugins created by cities and
+organizations accross the
+globe](https://lutece.paris.fr/lutece/community.html). A team
+considering adopting Lutece and working with a vendor to create
+several specific extensions wouldn't worry if the vendor hasn't
+contributed to the main platform but would look for contribution to
+several existing extensions as a sign of experience and competence.
 
 **KEY RECOMMENDATION** Diversity among participants making the most
 resource investments in an open source project indicates stability,
@@ -18,33 +27,48 @@ diversity in areas like employers of contributors or of vendors
 providing support services, such as customization, deployment
 assistance, maintenance and operations, and training.
 
-EXAMPLE: [55 commerical businesses](https://mifos.org/directory) provide a broad array of supporting services around the financial inclusion DPG [Mifos](https://mifos.org/), from custom development and hosting to business consulting and deployment support. 
+EXAMPLE: [55 commerical businesses](https://mifos.org/directory)
+provide a broad array of supporting services around the financial
+inclusion DPG [Mifos](https://mifos.org/), from custom development and
+hosting to business consulting and deployment support.
 
-[TODO: MIFOS has a lot of partners but I don't see a lot of this showing up in the public repo. I quickly looked at dev forum mailing list and it seems pretty diverse, so I think the above is fair enough to say. Not sure if an example comes to someone else's mind? Mifos web site also says they have a marketplace/app store but I couldn't find a link or other reference online...]
+(TODO: MIFOS has a lot of partners but I don't see a lot of this
+showing up in the public repo. I quickly looked at dev forum mailing
+list and it seems pretty diverse, so I think the above is fair enough
+to say. Not sure if an example comes to someone else's mind? Mifos web
+site also says they have a marketplace/app store but I couldn't find a
+link or other reference online...)
 
 **KEY RECOMMENDATION**: Encouraging commercial participation can be
 useful to a DPG's adoption and sustainability, but take care to foster
 diverse commercial actors and be wary of creating commerical
 opportunities that could permit unfair advantage.
 
-EXAMPLE: The DPG [Mojaloop](https://mojaloop.io/) publishes a [list](https://mojaloop.io/mojaloop-business-directory) of consultants, systems integrators,
-training organizations, business operations supporters and other
-solution providers, vetted against a published list of criteria. They also [host open training,
-networking, and business development
-events](https://mojaloop.io/category/events/) to connect these commerical participants to new business opportunities. 
+EXAMPLE: The DPG [Mojaloop](https://mojaloop.io/) publishes a
+[list](https://mojaloop.io/mojaloop-business-directory) of
+consultants, systems integrators, training organizations, business
+operations supporters and other solution providers, vetted against a
+published list of criteria. They also [host open training, networking,
+and business development events](https://mojaloop.io/category/events/)
+to connect these commerical participants to new business
+opportunities.
 
 **KEY RECOMMENDATION**: Financial sustainability can look different across a project's
 stages. The types and sources of available funding options might change as a project
 progresses.
 
-EXAMPLE: Your agency might be able to cover seed funding, as was the case with the World Bank's Global Facility for Disaster Reduction and Recovery (GFDDR) with the [GeoNode project](https://geonode.org/). Philanthropic funds might help you pilot the project in particular locations, as was the case with the
+EXAMPLE: Your agency might be able to cover seed funding, as was the
+case with the World Bank's Global Facility for Disaster Reduction and
+Recovery (GFDDR) with the [GeoNode
+project](https://geonode.org/). Philanthropic funds might help you
+pilot the project in particular locations, as was the case with the
 [DHIS2](https://dhis2.org/), or to scale, as was the case with
-[OpenSRP](https://wiki.digitalsquare.io/index.php/Digital_Square_Investments_in_Global_Goods#Notice_B_Investments). Charging for use might cover ongoing maintenance costs. For example, the DPG [ODK](https://getodk.org/) is free as a self-hosted solution for
-offline data collection, but the organization also provides [cloud-based hosting at different pricing
-tiers](https://getodk.org/#odk-cloud). 
-
-
-
+[OpenSRP](https://wiki.digitalsquare.io/index.php/Digital_Square_Investments_in_Global_Goods#Notice_B_Investments). Charging
+for use might cover ongoing maintenance costs. For example, the DPG
+[ODK](https://getodk.org/) is free as a self-hosted solution for
+offline data collection, but the organization also provides
+[cloud-based hosting at different pricing
+tiers](https://getodk.org/#odk-cloud).
 
 Understanding how to work with, participate in, and foster a
 successful open source project is not just a matter of understanding
@@ -157,7 +181,7 @@ patterns and practices in successful open source projects that operate
 in similar contexts.  
  
 For example, in evaluating an existing open source project, you
-wouldn’t expect a "rocket ship" project to invest in supporting new
+wouldn't expect a "rocket ship" project to invest in supporting new
 contributors, and you'd want to plan any contribution and
 participation accordingly, with personnel with some level of open
 source familiarity.  Simlarly, if you're planning to create your own
@@ -180,7 +204,7 @@ available).
   take more points of view into account.  An example would be the
   [Apache HTTP Server project](https://httpd.apache.org/).  The DPG
   [Apache Fineract](https://fineract.apache.org), which provides core
-  financial services functionality for the world’s 2 billion
+  financial services functionality for the world's 2 billion
   underbanked and unbanked, might also fit here, or it could be viewed
   more as a controlled ecosystem (see below).  Again, exact
   categorization isn't as important how the exercise gets you thinking
@@ -225,7 +249,7 @@ available).
   own separate but duplicative solution.  For
   example:[Kubernetes](https://kubernetes.io/), an open-source system
   for automating deployment, scaling, and management of containerized
-  applications. [X-Road's(™) distributed data
+  applications. [X-Road's distributed data
   exchange](https://x-road.global/x-road-technology-overview) is a DPG
   example here as well.
 
@@ -291,7 +315,7 @@ available).
   [Lutece](https://lutece.paris.fr/lutece/), an open source platform
   for municipal digital services, is a controlled ecosystem project
   that supports over 400 plugins created by cities and organizations
-  accross the globe.  Estonia's DPG X-Road(™) (now managed by the Nordic
+  accross the globe.  Estonia's DPG X-Road (now managed by the Nordic
   Institute for Interoperability Solutions (NIIS)) fits here, with its
   [support for
   extensions](https://x-road.global/xroad-technology-partners-companies),
@@ -437,7 +461,9 @@ long, so let's leave off for the moment and not go deeper than we
 need.  Note: Victor
 [suggests](https://github.com/unicef/publicgoods-toolkit/pull/12#discussion_r651325121)
 including a mapping/analysis of some existing DPGs to the archetypes.
-We can add that analysis after doing some interviews.)<-- SUSY NOTE: some DPG examples added above>
+We can add that analysis after doing some interviews.)
+
+(TBD: from Susy: some DPG examples added above.)
 
 ## Community Diversity
 
@@ -462,7 +488,9 @@ services -- simply because these aspects of diversity are so often
 overlooked, and yet are so important to the health and success of a
 DPG.  This diversity is particularly important to projects that aren't
 speciality software libraries, although even there overreliance on one
-contributor type can be problematic. Note that it can take some sleuthing to figure out the backgrounds of contributors, who often use a non-work related identifier or even pseudonyms. 
+contributor type can be problematic.  Note that it can take some
+sleuthing to figure out the backgrounds of contributors, who often use
+a non-work related identifier or even pseudonyms.
 
 In considering diversity, including diversity of investment sources,
 it is useful to recall that participants tend to exercise control over
@@ -768,9 +796,11 @@ investment by commercial participants, they undertake to create
 commercial opportunities for participants.  For example, the [DPG
 Mojaloop publishes a list of consultants, systems integrators,
 training organizations, business operations supporters and other
-solution providers](https://mojaloop.io/mojaloop-business-directory), vetted against a published list of criteria. They also [host open training,
-networking, and business development
-events](https://mojaloop.io/category/events/) to connect these commerical participants to new business opportunities. Sometimes these
+solution providers](https://mojaloop.io/mojaloop-business-directory),
+vetted against a published list of criteria. They also [host open
+training, networking, and business development
+events](https://mojaloop.io/category/events/) to connect these
+commerical participants to new business opportunities.  Sometimes these 
 opportunities tend to reward more active project participants.  So
 long as these opportunities do not start to create monopolizable
 advantages, they can be effective ways to promote sustainability for
@@ -908,13 +938,13 @@ module. (TBD LINK)
  
 A final note on sustainability.  As noted, health -- and thus
 sustainability -- depends on whether a project is genuinely meeting
-the needs of its stakeholders, if it’s thoughtfully set up to be
+the needs of its stakeholders, if it's thoughtfully set up to be
 responsive to changing needs, and if a well diversified set of
 stakeholders is engaged and contributing.  In many project types,
 stakeholders should probably include a varied set of commercial
 actors.
  
-There’s also a related question of how DPGs can attract ongoing
+There's also a related question of how DPGs can attract ongoing
 financial investments, what novel options are out there, and how these
 might be applied to the underresourced area of maintenance.
  
@@ -926,20 +956,20 @@ companies found new clients for their GeoNode expertise, which gave
 them additional incentive to continue contributing to GeoNode and
 invest in its success (and this infusion of input from an expanded
 user base made the product better).  George Gelaga-King, a Software
-Engineer from Sierra Leone’s Directorate of Science and Technology &
+Engineer from Sierra Leone's Directorate of Science and Technology &
 Innovation, confirmed the value of thinking about how to attract
 private actors by creating economic opportunities.  Depending on local
 circumstances and regulation, agencies themselves might even be able
 to offer commercial services around a DPG.
  
 (TODO: Can we ask George for a more specific quote about this?  The
-interview notes didn’t provide anything exact.  If there's a recording
+interview notes didn't provide anything exact.  If there's a recording
 we can pull it from there, or we can suggest something based on notes
 and make sure he's ok with it?  Or we can just pull the above.)
  
-However, fostering commercial engagement doesn’t exclude other
+However, fostering commercial engagement doesn't exclude other
 options. GeoNode also worked with universities and other NGOs and
-intergovernmental organizations. It’s notable how the engagement of
+intergovernmental organizations. It's notable how the engagement of
 just one PhD student helped distribute GeoNode knowledge and expertise
 as he moved jobs between different agencies and organizations.
  
@@ -967,7 +997,7 @@ Collaborative financing is also an option, as NORAD helped bring to
 the [Modular Open Source Identity Platform
 (MOSIP)](https://www.mosip.io/index.php).  A university team did
 directly support MOSIP, but the collaboration was limited, so outside
-funding from the [World Bank’s Identification for Development
+funding from the [World Bank's Identification for Development
 (ID4D)](https://id4d.worldbank.org) rounded out the financial needs.
 Collaborative financing can be managed through intergovernmental
 organizations, like the World Bank, or through an NGO, like the
@@ -981,7 +1011,11 @@ approaches.
  
 (TBD: from Karl: I'm not sure that all these named quotes are what we
 want.  Will check with UNICEF about this.)
-(SUSY: Totally understood. There's not a lot of good case study examples to support some of our points, so I turned to quotes from the interviews where I thought they could bring in the experiential insight)
+
+(TBD: response from Susy: Totally understood.  There's not a lot of
+good case study examples to support some of our points, so I turned to
+quotes from the interviews where I thought they could bring in the
+experiential insight.)
 
 George Gelaga-King spoke of how pooling financial and personnel
 resources across agencies to create a DPG is also an option, although
@@ -1002,8 +1036,8 @@ bonds](https://www.oecd.org/cfe/leed/SIBs-State-Play-Lessons-Final.pdf) (also
 known as development impact bonds) are another method of bringing
 private capital to the creation and maintenance of public goods. By
 definition, they seem like they would help bring more funding to the
-long-term maintenance needs of DPGs. They’ve received a lot of
-attention and some uptake, but to our knowledge, this model hasn’t
+long-term maintenance needs of DPGs. They've received a lot of
+attention and some uptake, but to our knowledge, this model hasn't
 been used by a DPG.
  
 Social impact investment funds take varied shapes and can function
@@ -1019,7 +1053,7 @@ private development projects is a similar option, like the ["percent
 for art"
 programs](https://en.unesco.org/creativity/policy-monitoring-platform/percent-art-scheme)
 that require private developers to allocate a certain percentage of
-the project’s budget to creating and maintaining public art. For some
+the project's budget to creating and maintaining public art. For some
 countries, creating a new tax on a company's IPO value could ensure
 capital gains help to pay for existing (and future) public
 infrastructure that created the conditions for the company's
@@ -1029,7 +1063,7 @@ Direct crowdfunding and sponsorship might also be a viable financing
 option in some cases.  GitHub recently launched [GitHub
 Sponsors](https://github.com/sponsors) to let individuals and
 companies donate directly to GitHub hosted open source projects.  And
-there are surely other options we haven’t come across or considered
+there are surely other options we haven't come across or considered
 here.
 
 Lastly, charging for use might be an option as well.  For example, the
@@ -1048,11 +1082,13 @@ The predication can be generalized by incorporating other risk
 frameworks.  The new social enterprise would offer subscriptions to
 the insights.
 
-The most important take-away is to think about your DPG’s financial
+The most important take-away is to think about your DPG's financial
 sustainability from a project lifecycle viewpoint.  Early design and
 feasibility work might be funded through research grants to a partner
 academic institute.  Seed funding might be at a low enough threshold
-for your agency to cover, as it was for the World Bank's Global Facility for Disaster Reduction and Recovery (GFDDR) with the GeoNode project, or you
+for your agency to cover, as it was for the World Bank's Global
+Facility for Disaster Reduction and Recovery (GFDDR) with the GeoNode
+project, or you
 might complement your investment in an external vendor with funding
 from a social impact investor.  Philanthropic funds might help you
 pilot the project in particular locations, as was the case with the
@@ -1064,7 +1100,7 @@ Mojaloop](https://appdevelopermagazine.com/the-gates-foundation-chats-about-moja
 The DPG [Primero](https://www.primero.org/resources) is a
 collaborative effort across aid organizations and agencies that
 started with initial seed funding of $1.5 million from the United
-States Agency for International Development’s (USAID) Office of
+States Agency for International Development's (USAID) Office of
 Foreign Disaster Assistance (OFDA) and the United States Center for
 Disease Control (CDC).  [Ongoing platform development costs are funded
 by UNICEF, while countries fund the costs for customizing the platform

--- a/introduction.md
+++ b/introduction.md
@@ -4,7 +4,7 @@ This operations-focused toolkit provides pragmatic, experience and
 evidence based advice for implementing Digital Public Goods (DPGs) at
 the country level.  These best practices should be useful to any
 organization interested in creating a DPG -- including commercial
-companies -- but it's main audiences are national government agencies
+companies -- but its main audiences are national government agencies
 and UN-affiliated agencies.  The toolkit was created through the
 support of the [UNICEF Office of
 Innovation](https://www.unicef.org/innovation/), as a co-champion of
@@ -20,12 +20,11 @@ and agency level policies that relate to Free and Open Source Software
 privacy and security; how to plan for and build organizational
 readiness to capture the full value of your DPG; tips for improving
 procurement, including sample contract language; and how to analyze an
-existing FOSS product for adoptability.  Key recommendations and
-suggestions for further reading are in the text and complemented with
+existing FOSS product for adoptability.  Key recommendations are highlighted at the beginning of every section, with additional recommendations and examples in the text. Suggestions for further reading can also be found in the text and complemented with
 a list of additional resources and tools in the
 [Appendix](/unicef/publicgoods-toolkit/appendix-resources-tools).  The
-paper also includes a checklist of recommendations and brief overviews
-of select exemplary 'open' projects, including a few DPGs.
+paper also includes a checklist of recommendations and [brief overviews
+of select exemplary 'open' projects, including a few DPGs]([Appendix](/unicef/publicgoods-toolkit/appendix-examples).
 
 Countries have different levels of knowledge and capabilities in open
 technologies and open development models.  We believe this guide is
@@ -60,7 +59,7 @@ APIs](/unicef/publicgoods-toolkit/appendix-resources-tools)).  The
 same holds true for open standards, which, among other things,
 describe how software should function.  We note a few unique points to
 be made about any differences between these DPG components in the
-paper.  However, open data and AI models merit deeper treatment in a
+paper.  However, the complexities around open data and AI models merit deeper treatment in a
 future revision.
 
 Lastly, it's worth prefacing this operational toolkit with a brief
@@ -77,12 +76,12 @@ measureable positives follow on from them.
 Re-usability breaks vendor lock-in and brings efficiency gains, lowers
 costs (and thus provides greater accessibility to broader
 populations), and focuses resources on local customization and
-innovation rather than foundational work.  Although the government of
+innovation rather than foundational work.  As an example, although the government of
 Sierra Leone created the [Open Data Sierra
 Leone](https://opendatasl.gov.sl/) portal to promote government
 transparency and accountability, their current investment angle views
 these open data sets as important[resources for innovators and
-investors](https://media.un.org/en/asset/k17/k17a9bg6o8) and they are
+investors](https://media.un.org/en/asset/k17/k17a9bg6o8), and they are
 figuring out how they can better support innovation linked to this
 open data.  Open source and open data can increase the speed of
 distribution and adoption of innovations as well.  The Philippine
@@ -102,9 +101,9 @@ volunteers, can ['scale horizontally' to send payments to teachers and
 schools](https://media.un.org/en/asset/k17/k17a9bg6o8).
 
 (TODO: confirm Philippines used CoWIN, I couldn't hear clearly in the
-presentation but it makes sense)
+presentation or confirm quickly through a search but it makes sense)
 
-Open source and open data provide an "off the shelf", low friction
+Open source and open data provide an "off the shelf," low friction
 model for collaboration to create and manage digital goods.  These
 collaborations -- often around foundational, shared infrastructure --
 lower barriers to entry, encourage innovation in areas of more value,

--- a/introduction.md
+++ b/introduction.md
@@ -20,7 +20,10 @@ and agency level policies that relate to Free and Open Source Software
 privacy and security; how to plan for and build organizational
 readiness to capture the full value of your DPG; tips for improving
 procurement, including sample contract language; and how to analyze an
-existing FOSS product for adoptability.  Key recommendations are highlighted at the beginning of every section, with additional recommendations and examples in the text. Suggestions for further reading can also be found in the text and complemented with
+existing FOSS product for adoptability.  Key recommendations are
+highlighted at the beginning of every section, with additional
+recommendations and examples in the text.  Suggestions for further
+reading can also be found in the text and complemented with
 a list of additional resources and tools in the
 [Appendix](/unicef/publicgoods-toolkit/appendix-resources-tools).  The
 paper also includes a checklist of recommendations and [brief overviews
@@ -59,8 +62,8 @@ APIs](/unicef/publicgoods-toolkit/appendix-resources-tools)).  The
 same holds true for open standards, which, among other things,
 describe how software should function.  We note a few unique points to
 be made about any differences between these DPG components in the
-paper.  However, the complexities around open data and AI models merit deeper treatment in a
-future revision.
+paper.  However, the complexities around open data and AI models merit
+deeper treatment in a future revision.
 
 Lastly, it's worth prefacing this operational toolkit with a brief
 summary of the benefits of an open approach.  You'll find numerous
@@ -76,8 +79,8 @@ measureable positives follow on from them.
 Re-usability breaks vendor lock-in and brings efficiency gains, lowers
 costs (and thus provides greater accessibility to broader
 populations), and focuses resources on local customization and
-innovation rather than foundational work.  As an example, although the government of
-Sierra Leone created the [Open Data Sierra
+innovation rather than foundational work.  As an example, although the
+government of Sierra Leone created the [Open Data Sierra
 Leone](https://opendatasl.gov.sl/) portal to promote government
 transparency and accountability, their current investment angle views
 these open data sets as important[resources for innovators and
@@ -249,9 +252,15 @@ boundaries.  DPGs are resources that enable entire communities to
 progress together.  Whenever government creates DPGs instead of
 proprietary resources, these are the policy goals it can create.
 
-The module on [Policy](/unicef/publicgoods-toolkit/policy) delves more deeply into recommended agency level policies on copyright, patent and trademarks for DPGs, while the [Procurement](/unicef/publicgoods-toolkit/community) module provides a few practical recommendations for managing licensing and usage concerns in working with vendors. 
+The module on [Policy](/unicef/publicgoods-toolkit/policy) delves more
+deeply into recommended agency level policies on copyright, patent and
+trademarks for DPGs, while the
+[Procurement](/unicef/publicgoods-toolkit/community) module provides a
+few practical recommendations for managing licensing and usage
+concerns in working with vendors.
 
-
-
-This paper is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International (CC BY-SA 4.0)](https://creativecommons.org/licenses/by-sa/4.0/). You can participate in its continued development and request changes at https://github.com/unicef/publicgoods-toolkit
-
+This paper is licensed under the [Creative Commons
+Attribution-ShareAlike 4.0 International (CC BY-SA
+4.0)](https://creativecommons.org/licenses/by-sa/4.0/).  You can
+participate in its continued development and request changes at
+https://github.com/unicef/publicgoods-toolkit.

--- a/policy.md
+++ b/policy.md
@@ -1,14 +1,26 @@
 # Policy
 
 **KEY RECOMMENDATION**: Use only well-known open source or open
-content licenses as defined by the [Digital Public Good Standard](https://digitalpublicgoods.net/standard/) and make sure copyright ownership is clearly
-established at the onset of a project.  Avoid mixing proprietary
-materials into a DPG, as this is not something you want to disentangle
-later, and resist the temptation to discourage commercial
-use of your DPG.  Indeed, commercial engagement can be very helpful to
-project sustainability, quality, and adoption.
+content licenses as defined by the [Digital Public Good
+Standard](https://digitalpublicgoods.net/standard/) and make sure
+copyright ownership is clearly established at the onset of a project.
+Avoid mixing proprietary materials into a DPG, as this is not
+something you want to disentangle later, and resist the temptation to
+discourage commercial use of your DPG.  Indeed, commercial engagement
+can be very helpful to project sustainability, quality, and adoption.
 
-EXAMPLE: The [MOSIP Digital ID Platform](https://www.mosip.io/) chose the [Mozilla Public License 2.0](https://docs.mosip.io/platform/license), a 'weak' copyleft license, so commercial partners and developers could create and distribute supporting software that interacts with the core open source MOSIP platform under *any* license, therefore broadening potential business models. MOSIP felt this approach would best attract diverse, committed commerical partners (e.g. system integrators, developers) to support customization and broader adoption as well as to build a [self-sustaining contributory ecosystem](https://documents1.worldbank.org/curated/ar/672901582561140400/pdf/Open-Source-for-Global-Public-Goods.pdf) that would keep the platform evolving. 
+EXAMPLE: The [MOSIP Digital ID Platform](https://www.mosip.io/) chose
+the [Mozilla Public License
+2.0](https://docs.mosip.io/platform/license), a 'weak' copyleft
+license, so commercial partners and developers could create and
+distribute supporting software that interacts with the core open
+source MOSIP platform under *any* license, therefore broadening
+potential business models. MOSIP felt this approach would best attract
+diverse, committed commerical partners (e.g. system integrators,
+developers) to support customization and broader adoption as well as
+to build a [self-sustaining contributory
+ecosystem](https://documents1.worldbank.org/curated/ar/672901582561140400/pdf/Open-Source-for-Global-Public-Goods.pdf)
+that would keep the platform evolving.
 
 
 **KEY RECOMMENDATION**: Trademarks can be powerful tools for branding
@@ -17,10 +29,11 @@ associated with it, and if so what the policy on ownership and
 enforcement of those trademarks should be, needs to be decided early
 and on a case-by-case basis.
 
-EXAMPLE: The Estonian Information System Authority maintains the trademark for the
-X-Road(™) DPG, even though its continued development is managed
-collaboratively across borders through the Nordic Institute for
-Interoperabilty Solutions. This control helps Estonia protect trust in its (and other's) X-Road(™) investments. 
+EXAMPLE: The Estonian Information System Authority maintains the
+trademark for the X-Road DPG, even though its continued development is
+managed collaboratively across borders through the Nordic Institute
+for Interoperabilty Solutions. This control helps Estonia protect
+trust in its (and other's) X-Road investments.
 
 
 **KEY RECOMMENDATION**: Secrecy doesn't equal security.  Open source
@@ -32,11 +45,23 @@ Investment Fund (OSTIF)](https://ostif.org) connect open-source
 projects with funding and logistical support for security audits and
 reviews.
 
-**KEY RECOMMENDATION**: Building for “high bar” cybersecurity and privacy
-regulation, such as the General Data Protection Regulation (GDPR) -- even if your DPG's country of deployment doesn't have strong regulation -- puts you in a better position to maintain a secure, trusted DPG that protects the most vulnerable and can be adopted beyond national borders. Protecting privacy and security requires
-continuous attention, starting from project inception. Privacy guidelines, pre-engagement diligence with vendors, and standardized templates and contracts will help you create a trustworthy DPG and meet the [DPG standard](https://digitalpublicgoods.net/standard/). 
+**KEY RECOMMENDATION**: Building for "high bar" cybersecurity and
+privacy regulation, such as the General Data Protection Regulation
+(GDPR) -- even if your DPG's country of deployment doesn't have strong
+regulation -- puts you in a better position to maintain a secure,
+trusted DPG that protects the most vulnerable and can be adopted
+beyond national borders. Protecting privacy and security requires
+continuous attention, starting from project inception. Privacy
+guidelines, pre-engagement diligence with vendors, and standardized
+templates and contracts will help you create a trustworthy DPG and
+meet the [DPG standard](https://digitalpublicgoods.net/standard/).
 
-EXAMPLE: MOSIP's [design principles around security and privacy](https://www.mosip.io/uploads/resources/5c97366200053Architectural%20Principle%20-%20Privacy%20and%20Security.pdf) -- reflected in its technical architecture and approach to handling vulnerabilities, threats, and audits -- have paved the way for adoption across countries with different regulatory environments, including India, Philippines, Ethiopia, Guinea, Sri Lanka and Morocco. 
+EXAMPLE: MOSIP's [design principles around security and
+privacy](https://www.mosip.io/uploads/resources/5c97366200053Architectural%20Principle%20-%20Privacy%20and%20Security.pdf)
+-- reflected in its technical architecture and approach to handling
+vulnerabilities, threats, and audits -- have paved the way for
+adoption across countries with different regulatory environments,
+including India, Philippines, Ethiopia, Guinea, Sri Lanka and Morocco.
 
 
 **KEY RECOMMENDATION**: Avoid misconceptions around open approaches
@@ -44,13 +69,21 @@ and privacy by clarifying the distinction between the DPG itself and
 the data it holds and manages with high-level decision makers and
 elected officials.  
 
-**KEY RECOMMENDATION**: Government procurement can be a powerful tool, creating open source commons around which entrepreneurial businesses and public-private partnerships can grow. Collaboration with academia and investment in education -- particularly early, comprehensive education to improve tech
-skills beyond digital literacy -- strengthens innovation and grows the talent pool. 
+**KEY RECOMMENDATION**: Government procurement can be a powerful tool,
+creating open source commons around which entrepreneurial businesses
+and public-private partnerships can grow. Collaboration with academia
+and investment in education -- particularly early, comprehensive
+education to improve tech skills beyond digital literacy --
+strengthens innovation and grows the talent pool.
 
-EXAMPLE: In Rwanda, Partners in Health (PIH) and the Kigali Institute of
-Science and Technology have a [partnership to train students to
-further develop and implement the OpenMRS DPG](https://openmrs.org/2010/12/03/open-source-health-information-business-ecosystems-in-resource-poor-environments/), while the Rwandan Development Board has paired graduates with seed capital and mentorship to help them create new health information technology support businesses to service over 400 clinics across the country.
-
+EXAMPLE: In Rwanda, Partners in Health (PIH) and the Kigali Institute
+of Science and Technology have a [partnership to train students to
+further develop and implement the OpenMRS
+DPG](https://openmrs.org/2010/12/03/open-source-health-information-business-ecosystems-in-resource-poor-environments/),
+while the Rwandan Development Board has paired graduates with seed
+capital and mentorship to help them create new health information
+technology support businesses to service over 400 clinics across the
+country.
 
 
 
@@ -139,8 +172,9 @@ a primer on open source licensing would be helpful.
 
 At the most basic level, government agencies engaging with open source
 can start with basic knowledge of a handful of software licenses.
-Permitted software licenses under the [Digital Public Good standard](https://digitalpublicgoods.net/standard/) are listed in UNICEF's
-[GitHub
+Permitted software licenses under the [Digital Public Good
+standard](https://digitalpublicgoods.net/standard/) are listed in
+UNICEF's [GitHub
 repository](https://github.com/unicef/publicgoods-candidates/blob/main/docs/licenses.md).
 All of these open source licenses have in common the basic permissions
 to run, copy, modify, and distribute the software, including AI
@@ -350,13 +384,15 @@ mind about copyright and DPGs:
 * Use only well-known open source or open content licenses.
 
   When publishing a DPG, you should always publish it under one of the
-  well-known and widely-used existing licenses as defined in the [Digital Public Good Standard](https://digitalpublicgoods.net/standard/).  Never make up your own
-  license: even if you have excellent lawyers draft it, no one else
-  will be familiar with your new license, and thus others' ability to
-  use your DPG will be impeded by an unnecessary extra burden of
-  license evaluation.  For the same reason, avoid the rarer licenses
-  except when you have a specific and strong reason to prefer one of
-  them.
+  well-known and widely-used existing licenses as defined in the
+  [Digital Public Good
+  Standard](https://digitalpublicgoods.net/standard/).  Never make up
+  your own license: even if you have excellent lawyers draft it, no
+  one else will be familiar with your new license, and thus others'
+  ability to use your DPG will be impeded by an unnecessary extra
+  burden of license evaluation.  For the same reason, avoid the rarer
+  licenses except when you have a specific and strong reason to prefer
+  one of them.
 
 A note about public domain open source.  It exists, and by its name it
 sounds promising.  However, using it is not desirable because it does
@@ -409,11 +445,12 @@ license](https://digitalpublicgoods.net/standard/) for software.
   write the no-proprietary-materials requirement into contracts with
   vendors, so that there is no ambiguity on the matter.
 
- **KEY RECOMMENDATION**: Use only well-known open source or open
-content licenses as defined by the [Digital Public Good Standard](https://digitalpublicgoods.net/standard/) and make sure copyright ownership is clearly
-established at the oset of a project.  Avoid mixing proprietary
-materials into a DPG.  This is not something you want to disentangle
-later.
+  **KEY RECOMMENDATION**: Use only well-known open source or open
+  content licenses as defined by the [Digital Public Good
+  Standard](https://digitalpublicgoods.net/standard/) and make sure
+  copyright ownership is clearly established at the oset of a project.
+  Avoid mixing proprietary materials into a DPG.  This is not
+  something you want to disentangle later.
 
 
 ### Copyright and Jurisdiction
@@ -545,7 +582,7 @@ DPG [Sunbird](https://www.sunbird.org/) is managed by the EkStep
 Foundation, which is the main supporter and developer of the
 extensible Sunbird Learning and knowledge management platform.  The
 Estonian Information System Authority maintains the trademark for the
-X-Road(™) DPG, even though its continued development is now done
+X-Road DPG, even though its continued development is now done
 collaboratively across borders through the Nordic Institute for
 Interoperabilty Solutions.
 
@@ -761,7 +798,7 @@ territories:
 **KEY RECOMMENDATION**: Even if your country doesn't have formal
 cybersecurity regulation, consider acting as if it did, especially
 around data privacy (see Privacy below) as it's particularly important
-in protecting vulnerable populations.  Building for “high bar”
+in protecting vulnerable populations.  Building for "high bar"
 cybersecurity regulation puts you in a better position to maintain a
 secure and trusted DPG.
 
@@ -784,9 +821,9 @@ trying to protect, with "thing" being very broadly defined.  A threat
 is what you're trying to protect against.  Per the U.S.  National
 Institute of Standards and Technology, a
 [vulnerability](https://csrc.nist.gov/glossary/term/vulnerability) is
-a “weakness in an information system, system security procedures,
+a "weakness in an information system, system security procedures,
 internal controls, or implementation that could be exploited or
-triggered by a threat source.” There are different definitions of
+triggered by a threat source." There are different definitions of
 risk, but basically it's the potential for loss and the probability of
 this occurring (loss multiplied by probability).  (The ISO definition
 of risk, which the [UNDP also
@@ -803,7 +840,7 @@ collaboration with stakeholders, ideally including security experts --
 identify potential threats, estimate a rank of their severity, and
 start outlining possible mitigations.  Threat modeling can be done
 from perspectives that center on a systems or asset view, but also
-from “thinking with your evil hat on”: in other words, thinking
+from "thinking with your evil hat on": in other words, thinking
 through all the ways users could be put at risk by bad actors (indeed,
 one specific threat modeling exercise is called "persona non grata").
 This should happen very early in the development process, ideally when
@@ -853,9 +890,9 @@ certain standards at a specific point in time.  There are guides and
 models for doing security risk assessments, such as from NIST (see
 Appendix)(TBD LINK), as well as different models for calculating
 probability in risk.  They can be as simple as a rating system from
-“not likely” to “expected,” as the UNDP's guidance note [“Managing
+"not likely" to "expected," as the UNDP's guidance note ["Managing
 Risks Across UNDP Programming and
-Operations”](https://info.undp.org/sites/ERM/Shared%20Documents/UNDP%20ERM%20Guide_Sept2019.pdf)
+Operations"](https://info.undp.org/sites/ERM/Shared%20Documents/UNDP%20ERM%20Guide_Sept2019.pdf)
 defines, to a more complicated model.  Choose whatever seems most
 likely to be both fitting and usable by your team and stick to it.
 The DPG OpenMRS took pared-down versions of well documented and well
@@ -899,9 +936,9 @@ Lastly, DPGs should have a policy of requiring a **risk management
 plan** for all discrete projects.  As its name implies, a risk
 management plan is a key tool to ensure your DPG is continually
 monitoring for risks and prepared to respond in a predetermined,
-agreed upon way.  Again, the [UNDP's guidance note “Managing Risks
+agreed upon way.  Again, the [UNDP's guidance note "Managing Risks
 Across UNDP Programming and
-Operations”](https://info.undp.org/sites/ERM/Shared%20Documents/UNDP%20ERM%20Guide_Sept2019.pdf)
+Operations"](https://info.undp.org/sites/ERM/Shared%20Documents/UNDP%20ERM%20Guide_Sept2019.pdf)
 is useful.  Its outline of key points in any risk management plan
 include :
 
@@ -978,7 +1015,7 @@ Many aspects of a DPG's success rely on getting data privacy right,
 from building trust with end users to attracting funding.  Data
 privacy is complex, but perhaps the most important recommendation is
 that protecting privacy requires continuous attention.  Data privacy
-is not a “one and done” effort.  It depends upon a close understanding
+is not a "one and done" effort.  It depends upon a close understanding
 of the full lifecycle of data within the DPG project, thinking through
 privacy *from* whom and *for* whom, and under what (possibly changing)
 circumstances.  Recent controversy over the United Nations High
@@ -1073,7 +1110,7 @@ There are well-tested, comprehensive design guides distilled from
 years of experience developing successful products that support the
 OECD's Privacy Principles and its various derivations in national laws
 and regulations.  The approach in these guides is described as
-“privacy by design.”
+"privacy by design."
 
 **KEY RECOMMENDATION**: Following privacy guidelines can
 help you pay attention to the actual needs of your end users to create
@@ -1092,8 +1129,8 @@ a privacy by design approach as one that:
 * Embeds privacy into the technical design from the start rather than
   retrofitting it;
 
-* Views privacy in a positive-sum manner (“win-win”) and not as a
-  zero-sum (“either/or”)
+* Views privacy in a positive-sum manner ("win-win") and not as a
+  zero-sum ("either/or")
 
 * Develops end-to-end security with a view to full-lifecycle
   protection
@@ -1136,7 +1173,7 @@ and save resources down the line.
 
 As you read through privacy guidelines, consider how the
 open aspects of your DPG project can help you better understand and
-build for privacy.  Recall that areas of “openness” are all points of
+build for privacy.  Recall that areas of "openness" are all points of
 potential collaboration.  For example, could collectively drafting
 documentation help you bring in meaningful participation from
 marginalized population groups? How might an open, user-focused
@@ -1191,7 +1228,7 @@ following:
   mitigations and place restrictions on how data provided to them in
   order to peform the contracted service can be used, retained, and
   stored.  The [Estonian government's recent audit of
-  X-Road(™)](https://eurosai-it.org/news/newsletter/1-2021/updates-from-itwg-members/estonia-x-road-and-audit)
+  X-Road](https://eurosai-it.org/news/newsletter/1-2021/updates-from-itwg-members/estonia-x-road-and-audit)
   found that many national agencies didn't use data service agreements
   or rarely checked for compliance where they were in place.
   Alarmingly, no audited national agency confirmed that their
@@ -1312,12 +1349,14 @@ Program includes deploying the open source
 and coordination with the Ministry of Public
 Education](https://pdf.usaid.gov/pdf_docs/PA00WRTP.pdf).
 
-USAID is also helping to improve Uzbekistan's Information and Communication Technology
-(ICT)-based instruction for grades 5 -11 in all public schools to help
-support the Ministry's goal of creating an "IT Nation".  The Ministry of Public Education's [IT
-Nation initiative](https://pdf.usaid.gov/pdf_docs/PA00WRTP.pdf) aims to produce grade 11 graduates who are able to
-work in cyber security, software development and testing, network
-administration, graphic design, animation, and game design.
+USAID is also helping to improve Uzbekistan's Information and
+Communication Technology (ICT)-based instruction for grades 5 -11 in
+all public schools to help support the Ministry's goal of creating an
+"IT Nation".  The Ministry of Public Education's [IT Nation
+initiative](https://pdf.usaid.gov/pdf_docs/PA00WRTP.pdf) aims to
+produce grade 11 graduates who are able to work in cyber security,
+software development and testing, network administration, graphic
+design, animation, and game design.
 
 
 [DHIS2 is an example of this early focus in
@@ -1446,5 +1485,5 @@ to opportunities for local innovation policy alignment.
 For example, how might public-private partnerships be formed to develop commonly needed open
 source components? Might these also tie into a relationship with a
 local university? Could local government provide tax incentives, or
-even something as “simple” as consistent Internet access and a safe
+even something as "simple" as consistent Internet access and a safe
 space, for partnerships that engage local students?

--- a/policy.md
+++ b/policy.md
@@ -1,20 +1,15 @@
 # Policy
 
-**KEY RECOMMENDATION**: Remember that the processes, culture and
-practices that support open source collaboration ultimately matter
-more to success than the particular open source license.  However, the
-license you choose can affect potential downstream business models.
-This isn't inherently a bad thing - indeed, these limitations were
-created in order to encourage the growth of a softare commons -- but
-are to be considered.  Mapping out your DPG's ecosystem is a helpful
-exercise here (see [Community and
-Ecosystem](/unicef/plicgoods-toolkit/community)).
-
 **KEY RECOMMENDATION**: Use only well-known open source or open
-content licenses and make sure copyright ownership is clearly
-established at the oset of a project.  Avoid mixing proprietary
-materials into a DPG.  This is not something you want to disentangle
-later.
+content licenses as defined by the [Digital Public Good Standard](https://digitalpublicgoods.net/standard/) and make sure copyright ownership is clearly
+established at the onset of a project.  Avoid mixing proprietary
+materials into a DPG, as this is not something you want to disentangle
+later, and resist the temptation to discourage commercial
+use of your DPG.  Indeed, commercial engagement can be very helpful to
+project sustainability, quality, and adoption.
+
+EXAMPLE: The [MOSIP Digital ID Platform](https://www.mosip.io/) chose the [Mozilla Public License 2.0](https://docs.mosip.io/platform/license), a 'weak' copyleft license, so commercial partners and developers could create and distribute supporting software that interacts with the core open source MOSIP platform under *any* license, therefore broadening potential business models. MOSIP felt this approach would best attract diverse, committed commerical partners (e.g. system integrators, developers) to support customization and broader adoption as well as to build a [self-sustaining contributory ecosystem](https://documents1.worldbank.org/curated/ar/672901582561140400/pdf/Open-Source-for-Global-Public-Goods.pdf) that would keep the platform evolving. 
+
 
 **KEY RECOMMENDATION**: Trademarks can be powerful tools for branding
 and building trust.  Whether a particular DPG should have trademarks
@@ -22,104 +17,42 @@ associated with it, and if so what the policy on ownership and
 enforcement of those trademarks should be, needs to be decided early
 and on a case-by-case basis.
 
-KEY RECOMMENDATION**: Resist the temptation to discourage commercial
-use of your DPG.  Indeed, commercial engagement can be very helpful to
-project sustainability, quality, and even adoption.
+EXAMPLE: The Estonian Information System Authority maintains the trademark for the
+X-Road(™) DPG, even though its continued development is managed
+collaboratively across borders through the Nordic Institute for
+Interoperabilty Solutions. This control helps Estonia protect trust in its (and other's) X-Road(™) investments. 
+
 
 **KEY RECOMMENDATION**: Secrecy doesn't equal security.  Open source
 provides conditions for stronger security, along with opportunities
-for collaboration and cost sharing around improving security.  Looking
-at your DPG ecosystem, are there possible partnerships and joint
-funding for security audits of the common open source software on
-which stakeholders rely? How about outside your immediate ecosystem?
-How might this link into local or national government investments in
-novation, either around new government services or to encourage local
-growth of SMEs?
+for collaboration and cost sharing to improve security. 
 
-**KEY RECOMMENDATION**: Even if your country doesn't have formal
-cybersecurity regulation, consider acting as if it did, especially
-around data privacy as it's particularly importance in protecting
-vulnerable populations.  Building for “high bar” cybersecurity
-regulation puts you in a better security to maintain a secure and
-usted DPG.
+EXAMPLE: Organizations like the non-profit [Open Source Technology
+Investment Fund (OSTIF)](https://ostif.org) connect open-source
+projects with funding and logistical support for security audits and
+reviews.
 
-**KEY RECOMMENDATION**: Define security related terminology and
-courage proper usage in your team to avoid miscommunication, mistakes
-and wasted effort.
+**KEY RECOMMENDATION**: Building for “high bar” cybersecurity and privacy
+regulation, such as the General Data Protection Regulation (GDPR) -- even if your DPG's country of deployment doesn't have strong regulation -- puts you in a better position to maintain a secure, trusted DPG that protects the most vulnerable and can be adopted beyond national borders. Protecting privacy and security requires
+continuous attention, starting from project inception. Privacy guidelines, pre-engagement diligence with vendors, and standardized templates and contracts will help you create a trustworthy DPG and meet the [DPG standard](https://digitalpublicgoods.net/standard/). 
 
-KEY RECOMMENDATION**: Make sure your threat model is well documented,
-pt updated, and revisited often.
+EXAMPLE: MOSIP's [design principles around security and privacy](https://www.mosip.io/uploads/resources/5c97366200053Architectural%20Principle%20-%20Privacy%20and%20Security.pdf) -- reflected in its technical architecture and approach to handling vulnerabilities, threats, and audits -- have paved the way for adoption across countries with different regulatory environments, including India, Philippines, Ethiopia, Guinea, Sri Lanka and Morocco. 
 
-**KEY RECOMMENDATION**: Although it might seem counterintuitive, open
-collaboration around identifying security threats -- and their tential
-mitigations -- can improve a DPG's security and build trust with
-stakeholders.  This might not be true in every case, but we encourage
-you to think of how crowdsourcing input can amplify your capacity and
-breadth of knowledge.  Of course, such collaborations would obviously
-need to have the problem tuned to the right audience.  *KEY
-RECOMMENDATION**: Create standardized templates for threat modeling,
-security risk assessments, cost/benefit analyses and risk management
-plans to help meet security regulation and improve security in
-practice.  This is an area where a DPG's open, collaborative approach
-again helpful, and secrecy is not your friend.
 
 **KEY RECOMMENDATION**: Avoid misconceptions around open approaches
 and privacy by clarifying the distinction between the DPG itself and
 the data it holds and manages with high-level decision makers and
-elected officials.  *KEY RECOMMENDATION**: Protecting privacy requires
-continuous attention, and it really starts from project inception.
-Also invest well in your pre-engagement diligence with vendors around
-privacy and security Create standardized data privacy and security
-questions for these vendor assessments.
+elected officials.  
 
-**KEY RECOMMENDATION**: Following privacy by design guidelines can
-help you pay attention to the actual needs of your end users to create
-a successful DPG while also building for legal and regulatory
-compliance.
+**KEY RECOMMENDATION**: Government procurement can be a powerful tool, creating open source commons around which entrepreneurial businesses and public-private partnerships can grow. Collaboration with academia and investment in education -- particularly early, comprehensive education to improve tech
+skills beyond digital literacy -- strengthens innovation and grows the talent pool. 
 
-KEY RECOMMENDATION**: An early prototype that works with dummy or live
-data (but not data at scale) can help better align DPG to good data
-practices.  Building and testing a prototype early in the development
-cycle helps surface problems and can better protect users and save
-resources down the line.  *KEY RECOMMENDATION**: Pay attention to how
-the open, collaborative aspects of the DPG project can strengthen its
-data privacy.
+EXAMPLE: In Rwanda, Partners in Health (PIH) and the Kigali Institute of
+Science and Technology have a [partnership to train students to
+further develop and implement the OpenMRS DPG](https://openmrs.org/2010/12/03/open-source-health-information-business-ecosystems-in-resource-poor-environments/), while the Rwandan Development Board has paired graduates with seed capital and mentorship to help them create new health information technology support businesses to service over 400 clinics across the country.
 
-**KEY RECOMMENDATION**: If you are offering goods and services to EU
-citizens or digitally monitoring their behavior in some way, there are
-few exceptions to the requirement to adhere to GDPR.  Arguably, GDPR
-also provides the highest protection for vulnerable communities, and
-even DPGs that function are areas not covered by GDPR should consider
-adherence.  Take advantage of the [GDPR guidance published by the
-EU](https://gdpr.eu/).
 
-**KEY RECOMMENDATION**: Standardizing contracts and data protection
-addendums, running Data Prection Impact Assessments, data mapping and
-data audits will help you meet GDPR requirements and are good sound
-security policies.
 
-**KEY RECOMMENDATION**: Think through your DPG's local ecosystem and
-consider opportunities for collaboration with educators, and keep in
-mind that non-coding contributions are also very valuable.  Although
-building local talent takes time, this early investment can pay off in
-a stronger talent pool within 5-10 years and unearth earlier benefits.
-Could you team up with secdary schools on a series of open source
-hackathons to introduce students to your DPG and get a few specific
-problems solved? Is there an opportunity to collaborate with a local
-university around open source, or even a local digital strategy in
-which your DPG might fit? Remember that changes and investments at a
-national level often happen because of proof points at a local level.
-
-**KEY RECOMMENDATION**: Government procurement is possibly the
-greatest lever for more alignment between FOSS policy and national
-innovation policy.  At a local level, once again, consider your DPG's
-ecosystem.  Points of alignment between your tech needs and those of
-local government point to opportunities for local innovation policy
-alignment.  How might public-private partnerships be formed to develop
-commonly needed open source components? Might these also tie into a
-relationship with a local university? Could local government provide
-tax incentives, or even something as “simple” as consistent Internet
-access and a safe space, for partnerships that engage local students?
 
 This module describes key national and international policies that
 shape the environment in which digital public goods (DPGs) function as
@@ -206,7 +139,7 @@ a primer on open source licensing would be helpful.
 
 At the most basic level, government agencies engaging with open source
 can start with basic knowledge of a handful of software licenses.
-Permitted software licenses under the DPG standard are listed on their
+Permitted software licenses under the [Digital Public Good standard](https://digitalpublicgoods.net/standard/) are listed in UNICEF's
 [GitHub
 repository](https://github.com/unicef/publicgoods-candidates/blob/main/docs/licenses.md).
 All of these open source licenses have in common the basic permissions
@@ -222,13 +155,13 @@ for your plans, and it *might* matter if you have plans to nurture
 commerical implementations.
 
 We broadly describe Free and Open Source Software ("FOSS") licenses as
-existing on a continuum from "permissive" to "protective".  
+existing on a continuum from "permissive" to "protective."  
 The most permissive licenses have the
 fewest restrictions.  They allow the broadest range of activity under
 the broadest range of conditions.  The more protective licenses are
 still quite permissive but they condition those permissions on
 compliance with certain requirements.  Among the commonly used
-licenses, those requirements concern "copyleft", which is the
+licenses, those requirements concern "copyleft," which is the
 requirement that when you distribute software, open source permissions
 attach to some or all of your improvements.  We usually distinguish
 between "weak" and "strong" copyleft as a way to categorize licenses
@@ -236,7 +169,7 @@ by how strict their copyleft requirements are.
 
 (TBD: Do we want a diagram of the license spectrum here?)
 
-These three categories, "permissive", "weak copyleft", and "strong
+These three categories, "permissive," "weak copyleft," and "strong
 copyleft" are well-recognized terms in the open source industry, and
 often the first step in considering a license is to classify it with
 one of those labels.  They are a common shorthand that often signal
@@ -344,10 +277,10 @@ developed for commercial purposes or that have restrictive licenses
 for some historical reason.
 
 The [Open Source Initiative](https://opensource.org/licenses) provide
-overviews of their approved licenses, along with a useful[FAQ](
+overviews of their approved licenses, along with a useful [FAQ](
 https://opensource.org/licenses).
 
-**KEY RECOMMENDATION**: Remember that the processes, culture and
+**RECOMMENDATION**: Remember that the processes, culture and
 practices that support open source collaboration ultimately matter
 more to success than the particular open source license.  However, the
 license you choose can affect potential downstream business models.
@@ -416,8 +349,8 @@ mind about copyright and DPGs:
 
 * Use only well-known open source or open content licenses.
 
-  When publishing a DPG, you should always publish it under a
-  well-known and widely-used existing license.  Never make up your own
+  When publishing a DPG, you should always publish it under one of the
+  well-known and widely-used existing licenses as defined in the [Digital Public Good Standard](https://digitalpublicgoods.net/standard/).  Never make up your own
   license: even if you have excellent lawyers draft it, no one else
   will be familiar with your new license, and thus others' ability to
   use your DPG will be impeded by an unnecessary extra burden of
@@ -477,10 +410,10 @@ license](https://digitalpublicgoods.net/standard/) for software.
   vendors, so that there is no ambiguity on the matter.
 
  **KEY RECOMMENDATION**: Use only well-known open source or open
-   content licenses and make sure copyright ownership is clearly
-   established at the outset of a project. Avoid mixing proprietary
-   materials into a DPG. This is not something you want to disentangle
-   later.
+content licenses as defined by the [Digital Public Good Standard](https://digitalpublicgoods.net/standard/) and make sure copyright ownership is clearly
+established at the oset of a project.  Avoid mixing proprietary
+materials into a DPG.  This is not something you want to disentangle
+later.
 
 
 ### Copyright and Jurisdiction
@@ -612,7 +545,7 @@ DPG [Sunbird](https://www.sunbird.org/) is managed by the EkStep
 Foundation, which is the main supporter and developer of the
 extensible Sunbird Learning and knowledge management platform.  The
 Estonian Information System Authority maintains the trademark for the
-X-road DPG, even though its continued development is now done
+X-Road(™) DPG, even though its continued development is now done
 collaboratively across borders through the Nordic Institute for
 Interoperabilty Solutions.
 
@@ -732,15 +665,15 @@ the security and privacy investments we outline here seem out of touch
 security and privacy to protect vulnerable populations, which have the
 most to lose from any failure.  This area is ripe for more
 coordination and collective investment.  The open source approach
-shines again here.  Indeed, the OpenMRS project found that the
+shines again here. Indeed, the OpenMRS project found that the
 communities forming around the project have ["taken on a movement of
-self-organization"](https://openmrs.org/2010/12/03/open-source-health-information-business-ecosystems-in-resource-poor-environments/),
+self-organization,"](https://openmrs.org/2010/12/03/open-source-health-information-business-ecosystems-in-resource-poor-environments/)
 sharing resources and tips in a self-reinforcing cycle of improvement.
 We foresee the development of more templates geared towards
 low-resource environments by DPG type (e.g.  healthcare versus
 education), with pooled resources to run security assessments (for
 proejct/product planning) and audits (to confirm security standards
-are met).  There are great opportunities for local businesses in this
+are met). There are great opportunities for local businesses in this
 area! We've provided what we believe are the most important agency and
 project level policies for DPGs to consider around security (and
 privacy) -- basically a deeper operational dive that aligns with the
@@ -758,8 +691,9 @@ area? Or a program of their own that might be in the future?)
 
 **KEY RECOMMENDATION**: Secrecy doesn't equal security.  Open source
 provides conditions for stronger security, along with opportunities
-for collaboration and cost sharing around improving security.  Looking
-at your DPG ecosystem, are there possible partnerships and joint
+for collaboration and cost sharing around improving security.  
+
+Looking at your DPG ecosystem, are there possible partnerships and joint
 funding for security audits of the common open source software on
 which stakeholders rely? How about for collectively creating and
 managing security assessments? How about outside your immediate
@@ -860,7 +794,7 @@ follows](https://info.undp.org/sites/ERM/Shared%20Documents/UNDP%20ERM%20Guide_S
 is "the effect of uncertainty on objectives.") There are also
 sophisticated models out there for calculating risk.
 
-**KEY RECOMMENDATION**: Define security related terminology and
+**RECOMMENDATION**: Define security related terminology and
 encourage proper usage in your team -- and vendors -- to avoid
 miscommunication, mistakes and wasted effort.
 
@@ -897,10 +831,10 @@ including STRIDE, DREAD, PASTA, Common Vulnerability Scoring System
 of putting your privacy policy into practice will be useful to many of
 these approaches.
 
-**KEY RECOMMENDATION**: Make sure your threat model is well
+**RECOMMENDATION**: Make sure your threat model is well
 documented, kept updated, and revisited often.
 
-**KEY RECOMMENDATION**: Although it might seem counterintuitive, open
+**RECOMMENDATION**: Although it might seem counterintuitive, open
 collaboration around identifying security threats -- and their
 potential mitigations -- can improve a DPG's security and build trust
 with stakeholders.  This might not be true in every case, but we
@@ -1089,7 +1023,7 @@ order.  See the
 some sample questionnaires.
 
 **KEY RECOMMENDATION**: Protecting privacy requires continuous
-attention, and it really starts from project inception.  Also invest
+attention, and it really starts from project inception.  Invest
 well in your pre-engagement diligence with vendors around privacy and
 security.  Create standardized data privacy and security questions for
 these vendor assessments.
@@ -1141,10 +1075,10 @@ OECD's Privacy Principles and its various derivations in national laws
 and regulations.  The approach in these guides is described as
 “privacy by design.”
 
-**KEY RECOMMENDATION**: Following privacy by design guidelines can
+**KEY RECOMMENDATION**: Following privacy guidelines can
 help you pay attention to the actual needs of your end users to create
 a successful DPG while also building for legal and regulatory
-compliance.
+compliance (and meeting the [DPG standard](https://digitalpublicgoods.net/standard/)).
 
 The World Bank's Identification for Development initiative summarizes
 a privacy by design approach as one that:
@@ -1172,8 +1106,8 @@ a privacy by design approach as one that:
 
 A recent [ID4D
 paper](https://www.id4africakhub.org/post/privacy-by-design-current-practices-in-estonia-india-and-austria)
-explores different legal, operational, and technical controls used by
-in Estonia, India, and Austria.[Estonia's Citizen
+ explores different legal, operational, and technical controls used by
+in Estonia, India, and Austria. [Estonia's Citizen
 Portal](https://www.eesti.ee/et) is a great example of a DPG that has
 followed privacy by design guidelines, particularly in how it gives
 users visibility -- and control -- over their data.  Estonia's
@@ -1187,10 +1121,10 @@ employees.
 
 The [Digital Impact Alliance's Principles for Digital
 Development](https://digitalprinciples.org/principle/address-privacy-security)
-provides further practical guidance to implementing privacy by design
+provides further practical guidance to implementing privacy 
 at different stages of a project.  During the design and develop
 phase, consider how your prototyping work could improve alignment with
-privacy by design principles -- such as putting users first,
+privacy principles -- such as putting users first,
 especially those most vulnerable -- as well as help you to create and
 test a data management and security plan.
 
@@ -1200,7 +1134,7 @@ data practices.  Building and testing a prototype early in the
 development cycle helps surface problems and can better protect users
 and save resources down the line.
 
-As you read through privacy by design guidelines, consider how the
+As you read through privacy guidelines, consider how the
 open aspects of your DPG project can help you better understand and
 build for privacy.  Recall that areas of “openness” are all points of
 potential collaboration.  For example, could collectively drafting
@@ -1233,7 +1167,7 @@ long history of privacy and human rights law.  It's deeply influenced
 data privacy and protection laws in other countries, such as India and
 Brazil.  It can also impact non-EU organizations.
 
-**KEY RECOMMENDATION**: If you are offering goods and services to EU
+**RECOMMENDATION**: If you are offering goods and services to EU
 citizens or digitally monitoring their behavior in some way, there are
 few exceptions to the requirement to adhere to GDPR.  Arguably, GDPR
 also provides the highest protection for vulnerable communities, and
@@ -1257,7 +1191,7 @@ following:
   mitigations and place restrictions on how data provided to them in
   order to peform the contracted service can be used, retained, and
   stored.  The [Estonian government's recent audit of
-  X-Road](https://eurosai-it.org/news/newsletter/1-2021/updates-from-itwg-members/estonia-x-road-and-audit)
+  X-Road(™)](https://eurosai-it.org/news/newsletter/1-2021/updates-from-itwg-members/estonia-x-road-and-audit)
   found that many national agencies didn't use data service agreements
   or rarely checked for compliance where they were in place.
   Alarmingly, no audited national agency confirmed that their
@@ -1376,18 +1310,15 @@ economy (part of USAID's support for the Uzbekistan Education Reform
 Program includes deploying the open source
 [OpenProject](https://www.openproject.org/) to help [project planning
 and coordination with the Ministry of Public
-Education](https://pdf.usaid.gov/pdf_docs/PA00WRTP.pdf)).
+Education](https://pdf.usaid.gov/pdf_docs/PA00WRTP.pdf).
 
-(TODO: I assume the below paragraph is talking about Uzbekistan MPE,
-but we should make that explicit if so.  -Karl)
-
-USAID is also improving Information and Communication Technology
+USAID is also helping to improve Uzbekistan's Information and Communication Technology
 (ICT)-based instruction for grades 5 -11 in all public schools to help
-support the Ministry's goal of creating an "IT Nation".  MPE's IT
-Nation initiative aims to produce grade 11 graduates who are able to
+support the Ministry's goal of creating an "IT Nation".  The Ministry of Public Education's [IT
+Nation initiative](https://pdf.usaid.gov/pdf_docs/PA00WRTP.pdf) aims to produce grade 11 graduates who are able to
 work in cyber security, software development and testing, network
 administration, graphic design, animation, and game design.
-https://pdf.usaid.gov/pdf_docs/PA00WRTP.pdf
+
 
 [DHIS2 is an example of this early focus in
 action](https://digitalpublicgoods.net/blog/the-transformative-role-of-academia-digital-public-goods/).
@@ -1425,8 +1356,8 @@ DPG](https://openmrs.org/2010/12/03/open-source-health-information-business-ecos
 which was adopted by the Rwandan Ministry of Health.  Graduates have
 been hired to work at the Ministry.  The Rwandan Development Board has
 also paired some graduates with seed capital and mentors to help them
-create new health information technology support businesses to servie
-the over 400 clinics across the coutnry.
+create new health information technology support businesses to service
+over 400 clinics across the country.
 
 The [State of Free and Open Source Software in India
 report](https://state-of-foss.in/the-state-of-foss-report.pdf)
@@ -1460,7 +1391,8 @@ consider opportunities for collaboration with educators, and keep in
 mind that non-coding contributions are also very valuable.  Although
 building local talent takes time, this early investment can pay off in
 a stronger talent pool within 5-10 years and unearth earlier benefits.
-Could you team up with secondary schools on a series of open source
+
+For example, could you team up with secondary schools on a series of open source
 hackathons to introduce students to your DPG and get a few specific
 problems solved? Is there an opportunity to collaborate with a local
 university around open source, or even a local digital strategy in
@@ -1485,10 +1417,9 @@ private companies -- to name a few!
 Bringing open source into innovation policies can direct innovation
 investment and harness competition power to explore areas of new
 value.  Open source provides a 'platform' around which entrepreneurial
-businesses and ecosystems can grow, It can foster the needed
-interdisciplinary, public-private collaborations we need to quickly
-create and scale solutions to our most challenging problems in health
-and the environment.
+businesses and ecosystems can grow. It can foster the needed
+interdisciplinary, public-private collaborations to quickly
+create and scale solutions to our most challenging problems.
 
 Government procurement is a strong lever for aligning FOSS and
 national innovation policy, amongst other areas of symbiotic benefits.
@@ -1510,8 +1441,9 @@ and open source, public-private partnerships, government procurement
 and its astutely comprehensive innovation policy is one to study.  At
 a local level, once again, consider your DPG's ecosystem.  Points of
 alignment between your tech needs and those of local government point
-to opportunities for local innovation policy alignment.  How might
-public-private partnerships be formed to develop commonly needed open
+to opportunities for local innovation policy alignment.  
+
+For example, how might public-private partnerships be formed to develop commonly needed open
 source components? Might these also tie into a relationship with a
 local university? Could local government provide tax incentives, or
 even something as “simple” as consistent Internet access and a safe

--- a/procurement.md
+++ b/procurement.md
@@ -11,27 +11,52 @@ the right vendor to the right task, break vendor lock-in, and reduce
 risks associated with any one vendor. It works best with an agile
 development model and modular technical design.
 
-EXAMPLE: California's modular contracting approach in overhauling some legacy systems in their Child Welfare system enabled them to work with multiple vendors to [dramatically reduce their delivery timeline from years to months](https://18f.gsa.gov/2016/11/15/modular-procurement-state-local-government/).
+EXAMPLE: California's modular contracting approach in overhauling some
+legacy systems in their Child Welfare system enabled them to work with
+multiple vendors to [dramatically reduce their delivery timeline from
+years to
+months](https://18f.gsa.gov/2016/11/15/modular-procurement-state-local-government/).
 
-**KEY RECOMMENDATION**: It is more important to attract
-bids from vendors who are experienced at open source development than
-to attract vendors who are experienced at government contracting. Conduct FOSS-specific outreach early in the RFP lifecycle and ensure solicitations are promoted in media specifically aimed at open source developers, not just at government software vendors.
+**KEY RECOMMENDATION**: It is more important to attract bids from
+vendors who are experienced at open source development than to attract
+vendors who are experienced at government contracting. Conduct
+FOSS-specific outreach early in the RFP lifecycle and ensure
+solicitations are promoted in media specifically aimed at open source
+developers, not just at government software vendors.
 
 **KEY RECOMMENDATION**: No matter what happens with intellectual
 property rights at the contracting stage, you must have the ability to
 deploy, (re)distribute, and modify the software under a suitable open
-source license (see the [DPG standard](https://digitalpublicgoods.net/standard/)). Contracts should prevent any vendor from encumbering further development and distribution on either trademark
-or patent grounds and expressly forbid satisfying
-any deliverable with software that includes any 'forever proprietary' component. Lastly, you should require acceptance of code into the open source repository as part of the definition of contractual
-delivery in software milestones. 
+source license (see the [DPG
+standard](https://digitalpublicgoods.net/standard/)). Contracts should
+prevent any vendor from encumbering further development and
+distribution on either trademark or patent grounds and expressly
+forbid satisfying any deliverable with software that includes any
+'forever proprietary' component. Lastly, you should require acceptance
+of code into the open source repository as part of the definition of
+contractual delivery in software milestones.
 
-[NOTE: We could rewrite the above recommendation to point out that granting exclusivity to a vendor for a bounded period could be a strategic move -- this would help us bring in the LA county example -- but I think that makes the recommendation too confusing. This is just a section where I found it hard to find specific examples.]
+(TBD: We could rewrite the above recommendation to point out that
+granting exclusivity to a vendor for a bounded period could be a
+strategic move -- this would help us bring in the LA county example --
+but I think that makes the recommendation too confusing. This is just
+a section where I found it hard to find specific examples.)
 
 
 
-This module describes a few procurement tips, such as modular contracting and open source quality assurance practices, that can help you better attract and manage vendors to create a successful open source DPG. 
+This module describes a few procurement tips, such as modular
+contracting and open source quality assurance practices, that can help
+you better attract and manage vendors to create a successful open
+source DPG.
 
-This module complements the Digital Impact Alliance's (DIAL) [Procurement of Digital Technology](https://procurement-digitalimpactalliance.org/) guide. That high level, comprehensive guide is aimed at helping government agencies manage general digital spend, from strategic planning through lifecycle management. This module dives more deeply into specifics around procurement related to open source software, particularly working with vendors. 
+This module complements the Digital Impact Alliance's (DIAL)
+[Procurement of Digital
+Technology](https://procurement-digitalimpactalliance.org/)
+guide. That high level, comprehensive guide is aimed at helping
+government agencies manage general digital spend, from strategic
+planning through lifecycle management. This module dives more deeply
+into specifics around procurement related to open source software,
+particularly working with vendors.
 
 Free and Open Source Software (FOSS) has rapidly become successful in
 the commercial sector.  Few modern enterprises can thrive without
@@ -134,13 +159,15 @@ point for state and local technology procurement as well (18F also
 addresses [non-federal modular contracting](
 https://18f.gsa.gov/2016/11/15/modular-procurement-state-local-government>)).
 
-This [modular approach to contracts has several benefits](https://github.com/18F/Modular-Contracting-And-Agile-Development/blob/master/_strategies/modular-procurement.md), beginning most importantly with
-breaking vendor lock-in.  At any point, a well-procured effort should
-provide recourse to multiple, credible vendors, each of whom has
-familiarity with the software, experience working with the other
-teams, and is able to work well with the agency's open source
-approach.  Every vendor becomes replaceable because none by itself is
-so crucial to the process that it cannot be replaced.
+This [modular approach to contracts has several
+benefits](https://github.com/18F/Modular-Contracting-And-Agile-Development/blob/master/_strategies/modular-procurement.md),
+beginning most importantly with breaking vendor lock-in.  At any
+point, a well-procured effort should provide recourse to multiple,
+credible vendors, each of whom has familiarity with the software,
+experience working with the other teams, and is able to work well with
+the agency's open source approach.  Every vendor becomes replaceable
+because none by itself is so crucial to the process that it cannot be
+replaced.
 
 With that goal in mind, 18F and others in the industry recommend
 structuring procurement as multiple contracts distributed among a
@@ -220,11 +247,12 @@ flexibility to accomodate customizations and better support local
 business and talent development.  As an example, [UNICEF contracted
 with a commercial software develoment
 vendor](https://www.unicef.org/evaluation/media/946/file/Primero.pdf)
-to create the open source [Primero](https://www.primero.org/) platform.  Deploying agencies can
-find their own vendors to design and build Primero forms and
-workflows, but if the project is complicated or the deploying agency
-is unable to source additional development and funds locally, UNICEF
-entered long-term agreements with four IT service providers to help.
+to create the open source [Primero](https://www.primero.org/) platform.
+Deploying agencies can find their own vendors to design and build
+Primero forms and workflows, but if the project is complicated or the
+deploying agency is unable to source additional development and funds
+locally, UNICEF entered long-term agreements with four IT service
+providers to help.
 
 Finally, we note that modular contracting aligns perfectly with the
 [Open Contracting Data Standard
@@ -250,7 +278,9 @@ challenge.  Smaller contracts for shorter periods of work provide less
 stability.  Vendors find themselves unable to make the long-term
 commitments needed to hire long-term employees instead of ad-hoc
 contractors tend not to stay as long.  That raises their costs, which
-of course eventually raises costs for your agency. Modular contracts can cause additional staffing complexity for vendors as well (see below, Vendor Staffing). (TBD LINK)
+of course eventually raises costs for your agency.  Modular contracts
+can cause additional staffing complexity for vendors as well (see
+below, Vendor Staffing). (TBD LINK)
 
 For these reasons, we suggest that agencies engaged in modular
 contracting place those contract modules in larger Master Services
@@ -665,9 +695,12 @@ expect less-experienced open source vendors to learn from the others.
 
 ## Data Protection and Security 
 
-Please see the Policy module (TBD LINK) for key points around security and data protection in vendor contracts, as well as the Appendix with some example contractural language (TBD LINK)  
+Please see the Policy module (TBD LINK) for key points around security
+and data protection in vendor contracts, as well as the Appendix with
+some example contractural language (TBD LINK)
 
-[SUSY NOTE: This is a new section that I felt should be noted here, even though it just refers to content elsewhere.]
+(TBD from Susy: This is a new section that I felt should be noted
+here, even though it just refers to content elsewhere.)
 
 ## Vendor Staffing
 

--- a/procurement.md
+++ b/procurement.md
@@ -7,92 +7,31 @@ RFP and contract language.  As that note says, let's put it into an
 appendix and refer to it there.)
 
 **KEY RECOMMENDATION**: Modular contracting can help to better connect
-the right vendor to the right task, break vendor lock-in and reduce
+the right vendor to the right task, break vendor lock-in, and reduce
 risks associated with any one vendor. It works best with an agile
 development model and modular technical design.
 
-**KEY RECOMMENDATION**: Agencies using modular contracting should
-consider placing these smaller contracts within larger Master Service
-Agreements for more efficiency and flexibility.
+EXAMPLE: California's modular contracting approach in overhauling some legacy systems in their Child Welfare system enabled them to work with multiple vendors to [dramatically reduce their delivery timeline from years to months](https://18f.gsa.gov/2016/11/15/modular-procurement-state-local-government/).
 
-**KEY RECOMMENDATION**: Remember that it is more important to attract
+**KEY RECOMMENDATION**: It is more important to attract
 bids from vendors who are experienced at open source development than
-to attract vendors who are experienced at government contracting.
-
-**KEY RECOMMENDATION**: Conduct FOSS-specific outreach early in the
-RFP lifecycle and ensure solicitations are promoted in media
-specifically aimed at open source developers, not just at government
-software vendors (in alignment with your agency's ethics and
-procurement rules).
-
-**KEY RECOMMENDATION**: Although contract amendments are possible
-(especially if they are just budget reallocation), you should seek
-contract terms that allow flexibility and iteration wholly within the
-terms of the agreement.
-
-**KEY RECOMMENDATION**: Include in contracts a process (and budget)
-for iterations and lightweight changes that do not require giving up
-other features and milestones.
-
-**KEY RECOMMENDATION**: Contracts should expressly forbid satisfying
-any deliverable with software that includes any proprietary component.
+to attract vendors who are experienced at government contracting. Conduct FOSS-specific outreach early in the RFP lifecycle and ensure solicitations are promoted in media specifically aimed at open source developers, not just at government software vendors.
 
 **KEY RECOMMENDATION**: No matter what happens with intellectual
 property rights at the contracting stage, you must have the ability to
 deploy, (re)distribute, and modify the software under a suitable open
-source license.
+source license (see the [DPG standard](https://digitalpublicgoods.net/standard/)). Contracts should prevent any vendor from encumbering further development and distribution on either trademark
+or patent grounds and expressly forbid satisfying
+any deliverable with software that includes any 'forever proprietary' component. Lastly, you should require acceptance of code into the open source repository as part of the definition of contractual
+delivery in software milestones. 
 
-**KEY RECOMMENDATION**: Contracts terms must prevent a vendor from
-encumbering further development and distribution on either trademark
-or patent grounds.
+[NOTE: We could rewrite the above recommendation to point out that granting exclusivity to a vendor for a bounded period could be a strategic move -- this would help us bring in the LA county example -- but I think that makes the recommendation too confusing. This is just a section where I found it hard to find specific examples.]
 
-**KEY RECOMMENDATION**: Integrating Open Source Quality Assurance
-(OSQA) practices into procurement, vendor management and your own
-planning helps ensure vendors follow-through on the open source
-development *process* as well as the product. Bringing up OSQA
-requirements early in vendor engagement signals your seriousness about
-open source success and puts vendors on notice, which is particularly
-helpful when relying on vendors that don't have much open source
-experience. For a fuller description of what OSQA entails, please see
-a sample OSQA statement of work in the Appendix (TBD LINK).
 
-**KEY RECOMMENDATION**: You should participate directly in technical
-development, even if only to a small degree, in order to create
-credibility and connection with vendors and contractors and to
-contribute to maintaining a consistent open source culture. There are
-high, reusable dividends to this investment.
 
-**KEY RECOMMENDATION**: You should require acceptance of code into the
-open source repository as part of the definition of contractual
-delivery in software milestones.
+This module describes a few procurement tips, such as modular contracting and open source quality assurance practices, that can help you better attract and manage vendors to create a successful open source DPG. 
 
-**KEY RECOMMENDATION**: An agency should add OSQA elements to its
-requirements list when considering project roles.  If it does not plan
-to do OSQA in-house, it should consider contracting for it.
-
-**KEY RECOMMENDATIONS**: Smaller modular contracts can make business
-more difficult for smaller vendors, especially in managing staffing
-and costs. However, you can alleviate this by: designing a development
-schedule to minimize discontinuities in work and contracts; adopt the
-MSA structure, which enables vendors to operate under multiple
-contract modules at once, each with different end dates; specify work
-in sets that fit under caps that allow contracting with streamlined
-processes; and begin the procurement process early, especially
-renewals for additional development stages.
-
-**KEY RECOMMENDATION**: While operation costs might be a separate
-line-item, much of the maintenance work should be part of the ongoing,
-modular improvement that keeps software current and prevents an agency
-from having to start over. Be sure to build monthly carrying costs
-into your budget.
-
-This module describes how a modular contracting approach to
-procurement can help you manage vendors to create a successful DPG. It
-includes tips for open source related Requests for Proposals (RFPs)
-and creating good open source focused contracts with vendors. The
-Policy module (TBD LINK) includes points around security and data
-protection in vendor contracts, with some example language in the
-Appendix. (TBD LINK)
+This module complements the Digital Impact Alliance's (DIAL) [Procurement of Digital Technology](https://procurement-digitalimpactalliance.org/) guide. That high level, comprehensive guide is aimed at helping government agencies manage general digital spend, from strategic planning through lifecycle management. This module dives more deeply into specifics around procurement related to open source software, particularly working with vendors. 
 
 Free and Open Source Software (FOSS) has rapidly become successful in
 the commercial sector.  Few modern enterprises can thrive without
@@ -138,7 +77,7 @@ projects.
 Time will tell, but the open source, open standards based modular
 approach might also make DPGs particularly attractive to funders, as
 one investment can reap a significantly compounded return as that
-module gets adapted and re-used. OpenAPIs and a modular architecture
+module gets adapted and re-used. Open APIs and a modular architecture
 can also help bring in funding for specific use cases, as was the case
 for DHIS2 and philanthropic funding for [integrating DHIS2 with
 Microsoft
@@ -179,20 +118,6 @@ succeed at FOSS projects.  It does suggest, though, that
 approaches should be designed with care for the particular constraints
 and opportunities found in public agencies.
 
-(TBD: The paragraph below was clearly meant to have a link to
-something?  Ask Susy -- I think she added the para.)
-
-A buyer's category management guide and resources for the Procurement
-of Digital Technologies in furthering the Sustainable Development
-Goals.  The guide is designed to provide a customised framework and
-toolset to be applied when procuring digital goods and services,
-within the framework of national procurement policies and procedures.
-
-The guide follows a step by step process that covers both the
-strategic planning and alignment of stakeholders across the digital
-category as a whole, and provides support across the entire category
-management lifecycle.
-
 ## Modular Contracting
 
 One center of excellence in government development of FOSS software is
@@ -209,7 +134,7 @@ point for state and local technology procurement as well (18F also
 addresses [non-federal modular contracting](
 https://18f.gsa.gov/2016/11/15/modular-procurement-state-local-government>)).
 
-This approach has several benefits, beginning most importantly with
+This [modular approach to contracts has several benefits](https://github.com/18F/Modular-Contracting-And-Agile-Development/blob/master/_strategies/modular-procurement.md), beginning most importantly with
 breaking vendor lock-in.  At any point, a well-procured effort should
 provide recourse to multiple, credible vendors, each of whom has
 familiarity with the software, experience working with the other
@@ -295,7 +220,7 @@ flexibility to accomodate customizations and better support local
 business and talent development.  As an example, [UNICEF contracted
 with a commercial software develoment
 vendor](https://www.unicef.org/evaluation/media/946/file/Primero.pdf)
-to create the open source Primero platform.  Deploying agencies can
+to create the open source [Primero](https://www.primero.org/) platform.  Deploying agencies can
 find their own vendors to design and build Primero forms and
 workflows, but if the project is complicated or the deploying agency
 is unable to source additional development and funds locally, UNICEF
@@ -306,7 +231,7 @@ Finally, we note that modular contracting aligns perfectly with the
 DPG](https://standard.open-contracting.org/latest/en/).
 
 **KEY RECOMMENDATION**: Modular contracting can help to better connect
-the right vendor to the right task, break vendor lock-in and reduce
+the right vendor to the right task, break vendor lock-in, and reduce
 risks associated with any one vendor. It works best with an agile
 development model and modular technical design.
 
@@ -340,7 +265,7 @@ larger contract modules, especially as the project grows in scope.
 One might also allocate these larger modules among its existing set of
 vendors as a way to balance risk management with cost management.
 
-**KEY RECOMMENDATION**: Agencies using modular contracting should
+**RECOMMENDATION**: Agencies using modular contracting should
 consider placing these smaller contracts within larger Master Service
 Agreements for more efficiency and flexibility.
 
@@ -439,7 +364,7 @@ requires being clear about which requirements are truly fixed and
 which ones were added because they seem likely to be needed on the
 path toward a complete solution.
 
-**KEY RECOMMENDATION**: Although contract amendments are possible
+**RECOMMENDATION**: Although contract amendments are possible
 (especially if they are just budget reallocation), you should seek
 contract terms that allow flexibility and iteration wholly within the
 terms of the agreement.
@@ -453,7 +378,7 @@ adjustments.  Neither vendors nor agencies can be expected to predict
 every last detail of development in advance.  A process that requires
 such prediction is a broken process.
 
-**KEY RECOMMENDATION**: Include in contracts a process (and budget)
+**RECOMMENDATION**: Include in contracts a process (and budget)
 for iterations and lightweight changes that do not require giving up
 other features and milestones.
 
@@ -510,7 +435,7 @@ key point.
 **KEY RECOMMENDATION**: No matter what happens with intellectual
 property rights at the contracting stage, you must have the ability to
 deploy, (re)distribute, and modify the software under a suitable open
-source license.
+source license (see the [DPG standard](https://digitalpublicgoods.net/standard/)).
 
 For third-party open source software, this means that an agency must
 receive that software, clearly labeled, in a manner compliant with
@@ -682,7 +607,7 @@ work.  It will also help ensure that open source processes are
 followed in spirit as well as in letter, since lapses will be more
 readily apparent.
 
-**KEY RECOMMENDATION**: You should participate directly in technical
+**RECOMMENDATION**: You should participate directly in technical
 development, even if only to a small degree, in order to create
 credibility and connection with vendors and contractors and to
 contribute to maintaining a consistent open source culture. There are
@@ -709,7 +634,7 @@ module, but the point here is not that an agency should master all
 these techniques, just that it should identify and implement at least
 some approaches.
 
-**KEY RECOMMENDATION**: An agency should add OSQA elements to its
+**RECOMMENDATION**: An agency should add OSQA elements to its
 requirements list when considering project roles.  If it does not plan
 to do OSQA in-house, it should consider contracting for it.
   
@@ -740,12 +665,9 @@ expect less-experienced open source vendors to learn from the others.
 
 ## Data Protection and Security 
 
-(TBD: section incomplete)
+Please see the Policy module (TBD LINK) for key points around security and data protection in vendor contracts, as well as the Appendix with some example contractural language (TBD LINK)  
 
-implements adequate measures for ensuring the integrity,
-confidentiality and availability of data to mitigate security risks.
-
-data service agreements
+[SUSY NOTE: This is a new section that I felt should be noted here, even though it just refers to content elsewhere.]
 
 ## Vendor Staffing
 
@@ -827,7 +749,7 @@ successive contract modules.  The disruption from small gaps can be
 larger than intended, but longer-term, planned staffing adjustments
 are always an available tool, even when issuing modular contracts.
 
-**KEY RECOMMENDATIONS**: Smaller modular contracts can make business
+**RECOMMENDATION**: Smaller modular contracts can make business
 more difficult for smaller vendors, especially in managing staffing
 and costs. However, you can alleviate this by: designing a development
 schedule to minimize discontinuities in work and contracts; adopt the
@@ -899,7 +821,7 @@ development, combine the maintenance with slowly tending to structure
 and paying down the "technical debt" that accumulates in projects and
 degrades them over time.
 
-**KEY RECOMMENDATION**: While operational costs might be a separate
+**RECOMMENDATION**: While operational costs might be a separate
 line-item, much of the maintenance work should be part of the ongoing,
 modular improvement that keeps software current and prevents an agency
 from having to start over. Be sure to build monthly carrying costs

--- a/readiness.md
+++ b/readiness.md
@@ -1,49 +1,18 @@
 # Open Source Readiness
 
-**KEY RECOMMENDATION**: Look for the places where your lack of open
-source investment are causing problems that can be addressed by
-small-scale, low-risk, experimental engagement.  Start there, being
-sure to label these experiments as skill-building exercises.  Think
-about how you can engage your larger team or organization as you
-develop, making the learning relevant to their own needs and goals and
-bringing them along as allies.
-
-**KEY RECOMMENDATION**: Look for the places where your lack of open
-source investment are causing problems that can be addressed by
-small-scale, low-risk, experimental engagement.  Start there, being
-sure to label these experiments as skill-building exercises.  Think
-about how you can engage your larger team or organization as you
-develop, making the learning relevant to their own needs and goals and
-bringing them along as allies.
-
-**KEY RECOMMENDATION**: If you've been tracking your team's growth in
-execution capabilities and bringing others along on your learning
-journey, you should have a good *shared* understanding of what skills,
-processes and policies you need to execute successfully, along with
-proof points of the value such investments will bring.  (Remember that
-these skills can come from external vendors and the need to build
-local talent, as mentioned throughout this paper).  This will help you
-present a strong recommendation to your organization's leadership and
-help you move from the Hype to Proficient stage in McAffer's readiness
-model.
-
-**KEY RECOMMENDATION** At the organizational level, Open Source
-Program Offices can help teams work more effectively and efficiently
-in open source.  As you move up the readiness ladder, consider if such
-a centralized operational function would help your organization to
-execute better.
+**KEY RECOMMENDATION**: The path to building organizational capacity to execute well on an open source DPG can roughly follow 'readiness models' developed through experience in private industry. Consider starting with skill-building experiments in places where your lack of open source investment are causing problems (e.g. lack of re-usability) that could be addressed by relatively small-scale, lower-risk investments.  
 
 **KEY RECOMMENDATION**: Cost/benefit analyses and valuation frameworks
-are useful and necessary tools, but remember that they don’t capture
-the full value of open source investments.  Be sure to include areas
-of 'adjacent value' when assessing the overall value of your DPG.
-These can be multipliers to your project's valuation.
+can be useful and necessary tools in building a case for an open approach, but they don’t capture
+the full value of open source investments.  Be sure to include areas of 'adjacent value' when assessing and reporting on the overall value of your DPG. These can be multipliers to your project's valuation.
+
+EXAMPLE: The [GeoNode project](https://geonode.org/), initiated by the World Bank's Global Facility for Disaster Reduction and Recovery (GFDDR), realized significant but difficult-to-quantify value through the vibrant commercial community that grew around the project. In time, these contributors became so active and financially committed to the project's continued development that [GFDDR was able to scale back its investment](https://opendri.org/wp-content/uploads/2017/03/OpenDRI-and-GeoNode-a-Case-Study-on-Institutional-Investments-in-Open-Source.pdf). 
 
 Open source is all about execution.  Reaping the benefits of open
 source investment requires completing a series of difficult steps
 ranging from designing an initial strategy to building an appropriate
 community to leveraging the resulting dynamics for strategic
-advantage.  This module presents a somewhat abstract but experiential
+advantage, whether that be scaling to broad adoption quickly or orchestrating participants to focus on areas of needed innovation. This module presents a somewhat abstract but experiential
 based view of organizational readiness, including models to consider
 referencing, and practical advice for how to move your team along the
 path to masterful open source execution.  The Adoptability module (TBD
@@ -108,7 +77,7 @@ pragmatic.  We've found that stepping back every so often to reflect
 using such shared language and concepts helps teams stay grounded in
 the big picture, rather than focusing exclusively on the details.
 
-**KEY RECOMMENDATION**: Engage the team in a frank discussion about
+**RECOMMENDATION**: Engage the team in a frank discussion about
 your open source readiness and locate the team and the organization on
 McAffer's engagement model.  What might this level mean for
 opportunities for growth, what might it mean for potential problems?
@@ -164,8 +133,7 @@ relabel his "tolerance" phase as "experimentation".
 
 **KEY RECOMMENDATION**: Look for the places where your lack of open
 source investment are causing problems that can be addressed by
-small-scale, low-risk, experimental engagement (see Appendix for an
-example)(TBD LINK).  Start there, being sure to label these
+small-scale, low-risk, experimental engagement. Start there, being sure to label these
 experiments as skill-building exercises. Think about how you can
 engage your larger team or organization as you develop, making the
 learning relevant to their own needs and goals and bringing them along
@@ -225,7 +193,7 @@ policy is how that happens, and it requires management approval and
 resources.  Agencies that fail to provide this support from fairly
 high in the organization tend to level off at this level of readiness.
 
-**KEY RECOMMENDATION**: If you've been tracking your team's growth in
+**RECOMMENDATION**: If you've been tracking your team's growth in
 execution capabilities and bringing others along on your learning
 journey, you should have a good *shared* understanding of what skills,
 processes and policies you need to execute successfully, along with
@@ -261,84 +229,87 @@ with [18F](https://18f.gsa.gov/), which, after reaching relatively
 high levels of open source capability and knowledge, developed
 guidance for other agencies approaching open source.  GSA's Code.gov
 has created a
-[toolkit](https://github.com/GSA/code-gov-open-source-toolkit) that
-goes in-depth for approaching open source.
+[toolkit](https://github.com/GSA/code-gov-open-source-toolkit) that gives agencies 
+guidance around creating and maintaining federal source code inventories and open source repositories.
 
-**KEY RECOMMENDATION** At the organizational level, Open Source
+
+
+**RECOMMENDATION** At the organizational level, Open Source
 Program Offices can help teams work more effectively and efficiently
 in open source.  As you move up the readiness ladder, consider if such
 a centralized operational function would help the organization to
 execute better.
 
-A final note on understanding and communicating the value of open
+A final note on understanding and communicating the value or cost-effectiveness of open
 source.  Gaining a more sophisticated understanding of this value -
 and having that understanding more broadly shared across an
-organization - is both a prerequisite to and a marker of moving along
-these readiness models.
+organization and its supporters - is both a prerequisite to and a marker of moving along
+these readiness models. Moreover, organizational decision makers and funders will want to know
+the cost/benefit ratio or the return on their investment and might also want to
+compare the approach to alternatives. 
 
 Ultimately, the value of your DPG will depend upon how well you’ve met
 your goals: a qualitative and quantitative assessment of the DPG’s
-positive impact on people’s lives.  Measuring social impact is
-complex, and how you’ll measure that should be established along with
-goal setting.  Still, organizational decision makers will want to know
-the cost/benefit ratio of their investment and might also want to
-compare the approach taken with alternatives.
+positive impact on people’s lives.  How you’ll first estimate and later actually measure this social impact is one of the first items to define in your project -- this obviously goes hand-in-hand with goal setting -- and the certainty of your measurements should improve with time. 
 
-There are tools out there that can help you make some determinations,
-and it’s likely that some combination of these will be needed.  The
-Digital Impact Alliance publishes a great overview of five different
-ways of valuing the impact of ICT investments that includes guidance
+There are tools out there that can help you make some cost and benefit determinations, but none capture the full value of an open approach -- especially specific to your context -- and it’s likely that you'll need to modify some combination of these tools to your needs. Start from a holistic view of your project and map out potential benefits and related costs, being realistic about what you can actually measure and prioritizing what will have the most cost and/or the most benefit per the goals of your project. Not everything is relevant. See the Grameen Foundation's ROI analysis framework below for a good example of a thoughtfully bounded approach that's specific to their audience.
+
+The Digital Impact Alliance publishes a great overview of five different
+ways of valuing the impact of ICT investments, [A Valuing Impact Toolkit for ICT
+Investment](https://digitalimpactalliance.org/wp-content/uploads/2020/10/ICT4D-toolkit.pdf), that includes guidance
 on which might be most fitting, depending on factors such as available
-resources, skills and data [A Valuing Impact Toolkit for ICT
-Investment](https://digitalimpactalliance.org/wp-content/uploads/2020/10/ICT4D-toolkit.pdf)
-To get deeper into the cost assessment side, USAID has also published
-Software Global Goods Valuation Framework (with a Spreadsheet) to
-assess cumulative development costs by an analysis of retrospective
+resources, skills and data -- important considerations for any organization but perhaps particularly for those in low-resource environments.
+
+To get much deeper into the cost assessment side of software, USAID has published the
+[Software Global Goods Valuation Framework](https://www.usaid.gov/cii/software-global-goods-valuation-framework) (with an accompanying spreadsheet) to
+assess cumulative development costs through an analysis of both retrospective
 and ongoing costs.  Although aimed at digital health products, it fits
-other types as well.  Perhaps most interesting to this model is its
-inclusion of a method for analyzing the cost of code, called
+other application areas as well.  Perhaps most interesting to this model is its
+inclusion of a method for analyzing the cost of code, called the
 Constructive Cost Model (COCOMO 81).
 
-However, none of the models quantify and incorporate the value of what
-can sometimes be more intangible benefits of open source development
-very well, although their costs are generally captured in terms of FTE
-investment.
-
-For an example of how the World Bank measured the fiscal impact of
+For an example of how the World Bank measured the fiscal (not social) impact of
 Estonia's X-road(™) project (a post facto measure), see [Estonian
 e-Government Ecosystem: Foundation, Applications,
 Outcomes](https://thedocs.worldbank.org/en/doc/165711456838073531-0050022016/original/WDR16BPEstonianeGovecosystemVassil.pdf),
 which extrapolates a narrow view of fiscal value from the number of
-queries made to the system.
+queries made to the system. 
+
+The Grameen Foundation published an [in-depth financial ROI framework](https://mifos.org/blog/documenting-technology-impact-mifos-roi-model-case-studies/) to help microfinance institutions (MFIs) forecast and analyze the benefits of adopting [Mifos](https://mifos.org/), the open source platform for microfinance. It highlights that the decision to adopt and deploy Mifos cannot be based only on the ROI analysis, noting the importance of understanding non-financial intangibles, like creating a better foundation for future innovation. The framework doesn't include these intangible, which can have different prioritization and value across implementations.
+
+Despite that limitation -- and the fact that the framework is unique to Mifos and MFIs and thus isn't an exact model for other projects to follow -- it's a well reasoned approach to a broader view of benefits (categorized as increased revenues and decreased costs specific to how MFIs function) and costs (categorized as project expenses, like data migration and staff time) that's worth reviewing. For those looking to create a DPG with the goal of broad adoption across different locales with slightly different contexts, it's worth studying how the Grameen Foundation created this tool to help MFIs more effectively adopt their DPG.
+
+Again, none of the above models quantify and incorporate the value of the intangible benefits of open source very well, although their costs are generally captured.
 
 The World Bank’s [Open Data for Resilience Initiative & GeoNode:A Case
 Study in Institutional Investments in Open
 Source](https://opendri.org/wp-content/uploads/2017/03/OpenDRI-and-GeoNode-a-Case-Study-on-Institutional-Investments-in-Open-Source.pdf
-) also tries addresses valuation in a broader yet still effective way.
+) tries to bring in some intangibles in cost and valuation in a slightly more effective way.
 Although it’s hard to distill the approach taken in the paper into a
 formal framework, it can be described as paying attention to areas of
-adjacent value.  This approach falls out pretty naturally from
-thinking of an open source project as part of an ecosystem.
+adjacent value.  This approach aligns pretty naturally with
+thinking of an open source project as part of an ecosystem, which will likely be the case for most DPGs that aim for broad social impact.
 
 Looking only at the cost of writing code themselves versus the value
 received from sharing costs with partners, it’s estimated that the
 GeoNode project brought around a 200% return on investment (as of
-2017).  But the real value of open source development to Global
+2017).  But the real value of open source development to the World Bank's Global
 Facility for Disaster Reduction and Recovery (GFDRR), the leading
 organization behind GeoNode, was the self-sustaining open source
 GeoNode community that emerged and the benefits that community
-continues to deliver.  For example, a consortium of U.S.  government
-agencies quickly picked up core development work -- valued at over $1
-million USD -- which permitted GFDRR to tune its investments to
+continues to deliver.  For example, a consortium of U.S. government
+agencies quickly picked up development work on the core of GeoNode -- valued at over $1
+million USD -- which permitted GFDRR to tune its resource investments to
 features it specifically needed.  Companies began providing commercial
 support, helping to grow further investment in GeoNode.  A growing
 user base made it easier to identify and prioritize areas for
 improvement.  These are several of many aspects of GeoNode's community
-and ecosystem that prove theres's greater value in open source than
-what's captured in these valuation frameworks.
+and ecosystem that prove there's greater value in open source than
+what's captured in existing valuation frameworks.
+
 
 **KEY RECOMMENDATION**: Cost/benefit analyses and valuation frameworks
-are useful and necessary tools, but remember that they don’t capture
+can be useful and necessary tools, but remember that they don’t capture
 the full value of open source investments.  Be sure to include areas
 of 'adjacent value' when assessing the overall value of your DPG.
 These can be multipliers to your project's valuation.

--- a/readiness.md
+++ b/readiness.md
@@ -1,18 +1,36 @@
 # Open Source Readiness
 
-**KEY RECOMMENDATION**: The path to building organizational capacity to execute well on an open source DPG can roughly follow 'readiness models' developed through experience in private industry. Consider starting with skill-building experiments in places where your lack of open source investment are causing problems (e.g. lack of re-usability) that could be addressed by relatively small-scale, lower-risk investments.  
+**KEY RECOMMENDATION**: The path to building organizational capacity
+to execute well on an open source DPG can roughly follow 'readiness
+models' developed through experience in private industry. Consider
+starting with skill-building experiments in places where your lack of
+open source investment are causing problems (e.g. lack of
+re-usability) that could be addressed by relatively small-scale,
+lower-risk investments.
 
 **KEY RECOMMENDATION**: Cost/benefit analyses and valuation frameworks
-can be useful and necessary tools in building a case for an open approach, but they don’t capture
-the full value of open source investments.  Be sure to include areas of 'adjacent value' when assessing and reporting on the overall value of your DPG. These can be multipliers to your project's valuation.
+can be useful and necessary tools in building a case for an open
+approach, but they don't capture the full value of open source
+investments.  Be sure to include areas of 'adjacent value' when
+assessing and reporting on the overall value of your DPG. These can be
+multipliers to your project's valuation.
 
-EXAMPLE: The [GeoNode project](https://geonode.org/), initiated by the World Bank's Global Facility for Disaster Reduction and Recovery (GFDDR), realized significant but difficult-to-quantify value through the vibrant commercial community that grew around the project. In time, these contributors became so active and financially committed to the project's continued development that [GFDDR was able to scale back its investment](https://opendri.org/wp-content/uploads/2017/03/OpenDRI-and-GeoNode-a-Case-Study-on-Institutional-Investments-in-Open-Source.pdf). 
+EXAMPLE: The [GeoNode project](https://geonode.org/), initiated by the
+World Bank's Global Facility for Disaster Reduction and Recovery
+(GFDDR), realized significant but difficult-to-quantify value through
+the vibrant commercial community that grew around the project. In
+time, these contributors became so active and financially committed to
+the project's continued development that [GFDDR was able to scale back
+its
+investment](https://opendri.org/wp-content/uploads/2017/03/OpenDRI-and-GeoNode-a-Case-Study-on-Institutional-Investments-in-Open-Source.pdf).
 
 Open source is all about execution.  Reaping the benefits of open
 source investment requires completing a series of difficult steps
 ranging from designing an initial strategy to building an appropriate
 community to leveraging the resulting dynamics for strategic
-advantage, whether that be scaling to broad adoption quickly or orchestrating participants to focus on areas of needed innovation. This module presents a somewhat abstract but experiential
+advantage, whether that be scaling to broad adoption quickly or
+orchestrating participants to focus on areas of needed innovation.  
+This module presents a somewhat abstract but experientially
 based view of organizational readiness, including models to consider
 referencing, and practical advice for how to move your team along the
 path to masterful open source execution.  The Adoptability module (TBD
@@ -71,7 +89,7 @@ particularly useful.  It's simple but includes strategic components,
 accounts for realistic failure modes, and understands that open source
 readiness will be unevenly distributed in any agency large enough to
 have multiple teams.  We also like how it describes the phases of
-capability growth almost like generalized ‘mental models’ at an
+capability growth almost like generalized 'mental models' at an
 organization or team level in a way that's both abstract and
 pragmatic.  We've found that stepping back every so often to reflect
 using such shared language and concepts helps teams stay grounded in
@@ -133,11 +151,11 @@ relabel his "tolerance" phase as "experimentation".
 
 **KEY RECOMMENDATION**: Look for the places where your lack of open
 source investment are causing problems that can be addressed by
-small-scale, low-risk, experimental engagement. Start there, being sure to label these
-experiments as skill-building exercises. Think about how you can
-engage your larger team or organization as you develop, making the
-learning relevant to their own needs and goals and bringing them along
-as allies.
+small-scale, low-risk, experimental engagement.  Start there, being
+sure to label these experiments as skill-building exercises.  Think
+about how you can engage your larger team or organization as you
+develop, making the learning relevant to their own needs and goals and
+bringing them along as allies.
 
 Experiments come in many forms, but the most common first experiment
 is using some outside open source code and engaging the open source
@@ -229,8 +247,9 @@ with [18F](https://18f.gsa.gov/), which, after reaching relatively
 high levels of open source capability and knowledge, developed
 guidance for other agencies approaching open source.  GSA's Code.gov
 has created a
-[toolkit](https://github.com/GSA/code-gov-open-source-toolkit) that gives agencies 
-guidance around creating and maintaining federal source code inventories and open source repositories.
+[toolkit](https://github.com/GSA/code-gov-open-source-toolkit) that
+gives agencies guidance around creating and maintaining federal source
+code inventories and open source repositories.
 
 
 
@@ -240,76 +259,117 @@ in open source.  As you move up the readiness ladder, consider if such
 a centralized operational function would help the organization to
 execute better.
 
-A final note on understanding and communicating the value or cost-effectiveness of open
-source.  Gaining a more sophisticated understanding of this value -
-and having that understanding more broadly shared across an
-organization and its supporters - is both a prerequisite to and a marker of moving along
-these readiness models. Moreover, organizational decision makers and funders will want to know
-the cost/benefit ratio or the return on their investment and might also want to
-compare the approach to alternatives. 
+A final note on understanding and communicating the value or
+cost-effectiveness of open source.  Gaining a more sophisticated
+understanding of this value - and having that understanding more
+broadly shared across an organization and its supporters - is both a
+prerequisite to and a marker of moving along these readiness
+models. Moreover, organizational decision makers and funders will want
+to know the cost/benefit ratio or the return on their investment and
+might also want to compare the approach to alternatives.
 
-Ultimately, the value of your DPG will depend upon how well you’ve met
-your goals: a qualitative and quantitative assessment of the DPG’s
-positive impact on people’s lives.  How you’ll first estimate and later actually measure this social impact is one of the first items to define in your project -- this obviously goes hand-in-hand with goal setting -- and the certainty of your measurements should improve with time. 
+Ultimately, the value of your DPG will depend upon how well you've met
+your goals: a qualitative and quantitative assessment of the DPG's
+positive impact on people's lives.  How you'll first estimate and
+later actually measure this social impact is one of the first items to
+define in your project -- this obviously goes hand-in-hand with goal
+setting -- and the certainty of your measurements should improve with
+time.
 
-There are tools out there that can help you make some cost and benefit determinations, but none capture the full value of an open approach -- especially specific to your context -- and it’s likely that you'll need to modify some combination of these tools to your needs. Start from a holistic view of your project and map out potential benefits and related costs, being realistic about what you can actually measure and prioritizing what will have the most cost and/or the most benefit per the goals of your project. Not everything is relevant. See the Grameen Foundation's ROI analysis framework below for a good example of a thoughtfully bounded approach that's specific to their audience.
+There are tools out there that can help you make some cost and benefit
+determinations, but none capture the full value of an open approach --
+especially specific to your context -- and it's likely that you'll
+need to modify some combination of these tools to your needs. Start
+from a holistic view of your project and map out potential benefits
+and related costs, being realistic about what you can actually measure
+and prioritizing what will have the most cost and/or the most benefit
+per the goals of your project. Not everything is relevant. See the
+Grameen Foundation's ROI analysis framework below for a good example
+of a thoughtfully bounded approach that's specific to their audience.
 
-The Digital Impact Alliance publishes a great overview of five different
-ways of valuing the impact of ICT investments, [A Valuing Impact Toolkit for ICT
-Investment](https://digitalimpactalliance.org/wp-content/uploads/2020/10/ICT4D-toolkit.pdf), that includes guidance
-on which might be most fitting, depending on factors such as available
-resources, skills and data -- important considerations for any organization but perhaps particularly for those in low-resource environments.
+The Digital Impact Alliance publishes a great overview of five
+different ways of valuing the impact of ICT investments, [A Valuing
+Impact Toolkit for ICT
+Investment](https://digitalimpactalliance.org/wp-content/uploads/2020/10/ICT4D-toolkit.pdf),
+that includes guidance on which might be most fitting, depending on
+factors such as available resources, skills and data -- important
+considerations for any organization but perhaps particularly for those
+in low-resource environments.
 
-To get much deeper into the cost assessment side of software, USAID has published the
-[Software Global Goods Valuation Framework](https://www.usaid.gov/cii/software-global-goods-valuation-framework) (with an accompanying spreadsheet) to
-assess cumulative development costs through an analysis of both retrospective
-and ongoing costs.  Although aimed at digital health products, it fits
-other application areas as well.  Perhaps most interesting to this model is its
+To get much deeper into the cost assessment side of software, USAID
+has published the [Software Global Goods Valuation
+Framework](https://www.usaid.gov/cii/software-global-goods-valuation-framework)
+(with an accompanying spreadsheet) to assess cumulative development
+costs through an analysis of both retrospective and ongoing costs.
+Although aimed at digital health products, it fits other application
+areas as well.  Perhaps most interesting to this model is its
 inclusion of a method for analyzing the cost of code, called the
 Constructive Cost Model (COCOMO 81).
 
-For an example of how the World Bank measured the fiscal (not social) impact of
-Estonia's X-road(™) project (a post facto measure), see [Estonian
-e-Government Ecosystem: Foundation, Applications,
+For an example of how the World Bank measured the fiscal (not social)
+impact of Estonia's X-road project (a post facto measure), see
+[Estonian e-Government Ecosystem: Foundation, Applications,
 Outcomes](https://thedocs.worldbank.org/en/doc/165711456838073531-0050022016/original/WDR16BPEstonianeGovecosystemVassil.pdf),
 which extrapolates a narrow view of fiscal value from the number of
-queries made to the system. 
+queries made to the system.
 
-The Grameen Foundation published an [in-depth financial ROI framework](https://mifos.org/blog/documenting-technology-impact-mifos-roi-model-case-studies/) to help microfinance institutions (MFIs) forecast and analyze the benefits of adopting [Mifos](https://mifos.org/), the open source platform for microfinance. It highlights that the decision to adopt and deploy Mifos cannot be based only on the ROI analysis, noting the importance of understanding non-financial intangibles, like creating a better foundation for future innovation. The framework doesn't include these intangible, which can have different prioritization and value across implementations.
+The Grameen Foundation published an [in-depth financial ROI
+framework](https://mifos.org/blog/documenting-technology-impact-mifos-roi-model-case-studies/)
+to help microfinance institutions (MFIs) forecast and analyze the
+benefits of adopting [Mifos](https://mifos.org/), the open source
+platform for microfinance. It highlights that the decision to adopt
+and deploy Mifos cannot be based only on the ROI analysis, noting the
+importance of understanding non-financial intangibles, like creating a
+better foundation for future innovation. The framework doesn't include
+these intangible, which can have different prioritization and value
+across implementations.
 
-Despite that limitation -- and the fact that the framework is unique to Mifos and MFIs and thus isn't an exact model for other projects to follow -- it's a well reasoned approach to a broader view of benefits (categorized as increased revenues and decreased costs specific to how MFIs function) and costs (categorized as project expenses, like data migration and staff time) that's worth reviewing. For those looking to create a DPG with the goal of broad adoption across different locales with slightly different contexts, it's worth studying how the Grameen Foundation created this tool to help MFIs more effectively adopt their DPG.
+Despite that limitation -- and the fact that the framework is unique
+to Mifos and MFIs and thus isn't an exact model for other projects to
+follow -- it's a well reasoned approach to a broader view of benefits
+(categorized as increased revenues and decreased costs specific to how
+MFIs function) and costs (categorized as project expenses, like data
+migration and staff time) that's worth reviewing. For those looking to
+create a DPG with the goal of broad adoption across different locales
+with slightly different contexts, it's worth studying how the Grameen
+Foundation created this tool to help MFIs more effectively adopt their
+DPG.
 
-Again, none of the above models quantify and incorporate the value of the intangible benefits of open source very well, although their costs are generally captured.
+Again, none of the above models quantify and incorporate the value of
+the intangible benefits of open source very well, although their costs
+are generally captured.
 
-The World Bank’s [Open Data for Resilience Initiative & GeoNode:A Case
+The World Bank's [Open Data for Resilience Initiative & GeoNode:A Case
 Study in Institutional Investments in Open
 Source](https://opendri.org/wp-content/uploads/2017/03/OpenDRI-and-GeoNode-a-Case-Study-on-Institutional-Investments-in-Open-Source.pdf
-) tries to bring in some intangibles in cost and valuation in a slightly more effective way.
-Although it’s hard to distill the approach taken in the paper into a
-formal framework, it can be described as paying attention to areas of
-adjacent value.  This approach aligns pretty naturally with
-thinking of an open source project as part of an ecosystem, which will likely be the case for most DPGs that aim for broad social impact.
+) tries to bring in some intangibles in cost and valuation in a
+slightly more effective way.  Although it's hard to distill the
+approach taken in the paper into a formal framework, it can be
+described as paying attention to areas of adjacent value.  This
+approach aligns pretty naturally with thinking of an open source
+project as part of an ecosystem, which will likely be the case for
+most DPGs that aim for broad social impact.
 
 Looking only at the cost of writing code themselves versus the value
-received from sharing costs with partners, it’s estimated that the
+received from sharing costs with partners, it's estimated that the
 GeoNode project brought around a 200% return on investment (as of
-2017).  But the real value of open source development to the World Bank's Global
-Facility for Disaster Reduction and Recovery (GFDRR), the leading
-organization behind GeoNode, was the self-sustaining open source
-GeoNode community that emerged and the benefits that community
+2017).  But the real value of open source development to the World
+Bank's Global Facility for Disaster Reduction and Recovery (GFDRR),
+the leading organization behind GeoNode, was the self-sustaining open
+source GeoNode community that emerged and the benefits that community
 continues to deliver.  For example, a consortium of U.S. government
-agencies quickly picked up development work on the core of GeoNode -- valued at over $1
-million USD -- which permitted GFDRR to tune its resource investments to
-features it specifically needed.  Companies began providing commercial
-support, helping to grow further investment in GeoNode.  A growing
-user base made it easier to identify and prioritize areas for
-improvement.  These are several of many aspects of GeoNode's community
-and ecosystem that prove there's greater value in open source than
-what's captured in existing valuation frameworks.
+agencies quickly picked up development work on the core of GeoNode --
+valued at over $1 million USD -- which permitted GFDRR to tune its
+resource investments to features it specifically needed.  Companies
+began providing commercial support, helping to grow further investment
+in GeoNode.  A growing user base made it easier to identify and
+prioritize areas for improvement.  These are several of many aspects
+of GeoNode's community and ecosystem that prove there's greater value
+in open source than what's captured in existing valuation frameworks.
 
 
 **KEY RECOMMENDATION**: Cost/benefit analyses and valuation frameworks
-can be useful and necessary tools, but remember that they don’t capture
+can be useful and necessary tools, but remember that they don't capture
 the full value of open source investments.  Be sure to include areas
 of 'adjacent value' when assessing the overall value of your DPG.
 These can be multipliers to your project's valuation.

--- a/works-consulted.md
+++ b/works-consulted.md
@@ -48,13 +48,19 @@ default/files/documents/1864/Software_Global_Goods_Valuation_Framework_VFinal.pd
 
 * TBD: interview notes, of course
 
+* https://github.com/18F/Modular-Contracting-And-Agile-Development/blob/master/_strategies/modular-procurement.md
+
 * https://digitalpublicgoods.net/DPGA_Financial-Inclusion-DPG-Technical-Assessment.pdf
+
+* https://procurement-digitalimpactalliance.org/
 
 * https://pdf.usaid.gov/pdf_docs/PA00WRTP.pdf
 
 * https://opendatatoolkit.worldbank.org/docs/odra/odra_sierra_leone.pdf
 
 * https://media.un.org/en/asset/k17/k17a9bg6o8
+
+* https://mifos.org/blog/documenting-technology-impact-mifos-roi-model-case-studies/
 
 * https://appdevelopermagazine.com/the-gates-foundation-chats-about-mojaloop/
 
@@ -81,6 +87,11 @@ default/files/documents/1864/Software_Global_Goods_Valuation_Framework_VFinal.pd
 * (https://blog.fedecarg.com/2008/06/28/a-modular-approach-to-web-development)
 
 * https://18f.gsa.gov/tags/modular-contracting/
+
+* https://www.mosip.io/uploads/resources/5c97366200053Architectural%20Principle%20-%20Privacy%20and%20Security.pdf
+
+* https://www.mosip.io/uploads/resources/5cc84b0a08284Country%20Engagement%20Principles_v2.pdf
+ 
 
 * https://obamawhitehouse.archives.gov/sites/default/files/omb/procurement/guidance/modular-approaches-for-information-technology.pdf
 


### PR DESCRIPTION
Revised summary of recommendations. Key recommendations with examples where possible are at the start of every module. Recommendations are still woven throughout text, categorized by key (again, which are also in the summary, although sometimes edited and combined for brevity) or just as recs.

Related update made to the introduction

Included Grameen's MIFOS ROI evaluation to Readiness module

corrected a few small issues