### PR TITLE
Implement intra-document linking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to the Digital Public Goods Toolkit
+
+We welcome contributions to this toolkit.  If you're thinking of
+contributing, it may help to know a few things about how the
+[Markdown](https://daringfireball.net/projects/markdown/) source is
+arranged and how we generate the PDF output.
+
+For details about PDF generation, see the [Makefile](Makefile).
+
+In the Markdown source files, we observe the following conventions:
+
+* Use hard newlines (i.e., hard line breaks).  Put the line break at
+  somewhere between 72 and 80 columns.  It's okay for a source line to
+  run longer than 80 columns under certain circumstances, for example
+  if it's a long URL.  In general, just look at what's going on in the
+  source files and try to match that.
+
+* Use straight 'single quotes' and "double quotes", not their
+  ‘directional’ “counterparts”.  This makes the source files more
+  easily searchable.  Don't worry -- when the PDF is rendered, it will
+  have properly directional quotes.
+
+* To link to a section in another file, give both the filename and the
+  named anchor within that file.  For example: 
+
+  <pre>[Assessing Security](adoptability.md#assessing-security)</pre>
+
+  The filename portion is only there so that cross-file linking works
+  correctly on sites (like GitHub) that automatically render Markdown
+  files as HTML.  The filename portion is ignored in the PDF -- see
+  the [Makefile](Makefile) for details of how this is done -- since
+  the toolkit becomes a single PDF with no internal file boundaries.
+
+  Remember that Markdown section names automatically produce
+  corresponding destination anchors.  For example, in the file
+  `adoptability.md` there is a section header "## Assessing Security",
+  and that section's name corresponds to the HTML-style anchor
+  "#assessing-security" used in the example above.
+
+* Section names must be unique across all source files.
+
+  This is a consequence of the intra-document linking method described
+  previously: since the PDF has no internal file boundaries, it relies
+  on section names being unique across the entire document.
+
+* Use either "TBD" or "TODO" to mark a place where something isn't
+  complete or where you would especially like feedback from others.
+
+* When submitting a change, please don't mix small, non-substantive
+  fixes (like formatting fixes, typo fixes, etc) with substantive
+  changes.  It's much easier for us to review suggested contributions
+  when those two things are kept separate.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ This toolkit is the work of the [UNICEF Office of Innovation](https://www.unicef
 
 6. It is made open source and/or published under Creative Commons – Attribution-ShareAlike 4.0 International (CC BY-SA 4.0) where possible and unless otherwise specified 
 
+## Contributing
+
+Please see the [contribution guide](CONTRIBUTING.md) for information
+on how to contribute to this toolkit.
+
 ## :memo: License
 
 This repository is primarily content, and it is licensed under a [Creative Commons Attribution ShareAlike 4.0 International License](LICENSE.md).

--- a/adoptability.md
+++ b/adoptability.md
@@ -114,7 +114,7 @@ Typically, the organizations that provide product-shaped offerings are
 also deeply involved in the project.  As you'll see below, that's one
 of the things to look for when evaluating both projects and vendors.
 
-## Security
+## Assessing Security
 
 There are no guarantees when it comes to computer and network
 security.  Even the largest companies and the most careful, thorough
@@ -694,8 +694,6 @@ spectrum, one will find a project's lead developer heroically also
 playing the support role.  That often works, but is sometimes an
 indication that the project overly depends on one person who might
 move on or burn out.
-
-## Internal Capacity Assessment
 
 (TODO: Maybe a note here about using open forums!  It looks like Mifos
 moved from https://discourse.mifos.org to Slack?  Or this is a good

--- a/appendix-apis.md
+++ b/appendix-apis.md
@@ -1,4 +1,4 @@
-# **Appendix: Introduction to APIs for Non-Technical Readers**
+# Appendix: Introduction to APIs for Non-Technical Readers
 
 An "Application Programming Interface" (API) is essentially a
 *contract* -- an agreement between two computer programs, perhaps

--- a/appendix-resources-tools.md
+++ b/appendix-resources-tools.md
@@ -1,4 +1,4 @@
-# **Appendix: Resources and Tools
+# Appendix: Resources and Tools
 
 Additional resources and tools are listed by topical module. 
 
@@ -7,8 +7,6 @@ purpose of this appendix and how it relates to the other appendices.
 Well, as per our discussion on 2021-10-13, we're maybe going to create
 some more topic-specific appendixes, so some of this will get moved to
 one of those then.
-
-## **Introduction**
 
 (TBD: Write introductory paragraphs.  Add a few resources for
 networking if possible.
@@ -38,7 +36,7 @@ talent and support at any sort of commercial start-up accelerator or
 incubator, which if not physically local might still be accessible and
 helpful to you online.
 
-**Benefits of Open Source**
+## Benefits of Open Source
 
 * The World Bank report [Open Source for Global Public
   Goods](https://openknowledge.worldbank.org/handle/10986/33401)
@@ -141,7 +139,7 @@ example, see a [recent job posting for a community
 managaer](https://www.kobotoolbox.org/join-our-team/project-community-engagement-coordinator.html)
 from the the team behind the Kobo Toolbox DPG (accessed Sept. 2021).
 
-## **COMMUNITY** 
+## Resources and Tools Appendix: Community
 
 This [2018 slide presentation of project
 archetypes](https://opentechstrategies.com/files/presentations/2018-finos/finos-presentation.html)
@@ -192,7 +190,7 @@ a thriving open source community. Some of our favorites include:
 
 * Code of conduct - https://wiki.openmrs.org/display/RES/OpenMRS+Code+of+Conduct
 
-## **POLICY**
+## Resources and Tools Appendix: Policy
 
 **Integrated Policy Approaches**
 
@@ -322,7 +320,7 @@ is similarly straightforward:
 * Unreleased policy should be kept closed.
 
 
-## **ADOPTABILITY**
+## Resources and Tools Appendix: Adoptability
 
 The [Open Source Maturity
 Model](https://en.wikipedia.org/wiki/OpenSource_Maturity_Model) is
@@ -334,7 +332,7 @@ weighting. More background is in this article by Bernard Golden in
 Review](https://timreview.ca/article/145), (May 2008).
 
 
-## **PROCUREMENT**
+## Resources and Tools Appendix: Procurement
 
 The Digital Impact Alliance's [Procurement Of Digital
 Technology](https://procurement-digitalimpactalliance.org/) is a

--- a/policy.md
+++ b/policy.md
@@ -168,7 +168,7 @@ DPG supportive policies.
 Before we get into context-setting national and agency level policies,
 a primer on open source licensing would be helpful.
 
-## Major Software Licenses and License Categories {#foss-licensing}
+## Major Software Licenses and License Categories
 
 At the most basic level, government agencies engaging with open source
 can start with basic knowledge of a handful of software licenses.
@@ -469,7 +469,7 @@ subject of litigation in multiple jurisdictions.
 
 
 
-## Patent {#patent}
+## Patent
 
 A patent is also a monopoly right, like a copyright, but it is a
 monopoly on a method or a mechanism for doing something.  Like

--- a/procurement.md
+++ b/procurement.md
@@ -1,4 +1,10 @@
-# FOSS Procurement For Government Agencies {#procurement}
+# Procurement
+
+(TBD: The original title of this module -- that is, the title for its
+main section, given above after the single "#" -- was as follows:
+"FOSS Procurement For Government Agencies {#procurement}".  Karl
+simplified it in order to match the relatively simple top-level names
+of the other modules, but he is open to feedback on that decision!)
 
 (TODO: Find more sample RFP or contract language to illustrate more
 points.  Include here or in Appendix.  UPDATE: see ref:f9f71f8d,

--- a/works-consulted.md
+++ b/works-consulted.md
@@ -1,4 +1,4 @@
-# **References** 
+# Works Consulted
 
 (TBD: UNICEF reports are pdf and have references at end I wasn't
 entirely sure how to handle citations for a paper that, I believe,


### PR DESCRIPTION
Implement intra-document linking and document it.

@lacabra, I've requested your review mainly for the `Makefile` part of this change, though I'd welcome your comments on the rest too.  @sstruble, I've flagged you as a reviewer mainly so you can look over the new `CONTRIBUTING.md` file, which describes (among other things) the new intra-doc linking method that you've been waiting for, and so that you can see the changes I made to a few section names in various Markdown files in order for that new linking method to work reliably.  (You don't have to re-do any of those section-name changes on your branches -- when we merge this in, we'll get the changes that way.  I'm happy to coordinate with you tomorrow on how to absorb the changes into your current working branch.)