### PR TITLE
Resolve all pending TODO / TBD items except one

### DIFF
--- a/adoptability.md
+++ b/adoptability.md
@@ -798,18 +798,14 @@ technical way.  Presence in those forums is a good way to stay in
 touch with the project's currents and to develop expertise that can be
 very useful to have in-house, even if you also have a support vendor.)
 
-## Internal Capacity Assessment
-
-(TBD: Plan for this section is to collect the relevant points from all
-the other sections and examine what specific internal capacities would
-be needed to take advantage of or implement the advice given in those
-points.)
-
-[TODO from Susy: I think OTS's deep implementation experience is needed
-here to outline what's most important and what's often overlooked in
-thinking about internal capacity. I started to draft some categories
-for how I'd approach this, but I'm not sure I'm able to get to most
-salient and experiential-based insight.]  
+**FUTURE WORK**: We were thinking of having a section "Internal
+Capacity Assessment" here.  To produrce it, one could start by
+collecting relevant points from all the other sections, then examine
+what specific internal capacities would be needed to take advantage of
+or implement the advice given in those points.  It should be limited
+to outlining what's most important and what's most often overlooked in
+thinking about internal capacity, for DPGs specifically; otherwise the
+topic could be too large and too general for this toolkit.
 
 ## Ecosystem Mapping for Adoptability
 
@@ -911,11 +907,8 @@ gaps or useful opportunties?
 
 ## Evaluation Checklist
 
-TBD: This will be a summarized, curated checklist based on the
+(TODO: This will be a summarized, curated checklist based on the
 sections above, particularly the HOWTO items in them, and will refer
-back to them (note: we need a format that supports such references
-well; maybe Markdown does, but if not then Asciidoc or others should
-be considered).  Because this will be based on the material above,
-we'll wait until the module has been through some review and settles
-down a bit more before making this summarized checklist.  See also
-previous TBD note re "trawl mode".
+back to them.  Because this will be based on the material above, we'll
+wait until the module has been through some review and settles down a
+bit more before making this summarized checklist.)

--- a/adoptability.md
+++ b/adoptability.md
@@ -804,8 +804,10 @@ collecting relevant points from all the other sections, then examine
 what specific internal capacities would be needed to take advantage of
 or implement the advice given in those points.  It should be limited
 to outlining what's most important and what's most often overlooked in
-thinking about internal capacity, for DPGs specifically; otherwise the
-topic could be too large and too general for this toolkit.
+thinking about internal capacity, for DPGs specifically, and ideally 
+come from talking through the toolkit with government agencies and 
+others involved with DPGs; otherwise the topic could be too large and 
+too general for this toolkit.  
 
 ## Ecosystem Mapping for Adoptability
 

--- a/adoptability.md
+++ b/adoptability.md
@@ -799,7 +799,7 @@ touch with the project's currents and to develop expertise that can be
 very useful to have in-house, even if you also have a support vendor.)
 
 **FUTURE WORK**: We were thinking of having a section "Internal
-Capacity Assessment" here.  To produrce it, one could start by
+Capacity Assessment" here.  To produce it, one could start by
 collecting relevant points from all the other sections, then examine
 what specific internal capacities would be needed to take advantage of
 or implement the advice given in those points.  It should be limited

--- a/appendix-examples.md
+++ b/appendix-examples.md
@@ -309,27 +309,3 @@ SORMAS [interoperates with District Health Information Software 2
 such as the electronic IDSR system and Epi
 Info](https://health.bmz.de/wp-content/uploads/studies/GHPC_SORMAS_full_version_final.pdf).
 It's also a Digital Square-approved global good.
-
-
-### Product: OpenHMIS
-
-(TBD: Karl and James to double-check this as an example product.)
-
-The United States' federal agency, Housing and Urban Development (HUD)
-operates a program called
-[HMIS](https://www.hudexchange.info/programs/hmis/), the Homeless
-Management Information System.  It is a data-collection effort used to
-inform policy at the state level.  States that receive federal support
-to address homelessness collect information to comply with funding
-program requirements.  The State of Georgia leads development of
-[OpenHMIS](http://openhmis.pcni.org/), an open-source package that
-helps states efficiently collect this information.
-
-**OpenHMIS is an example of where open source can play a lead role in
-making government operations more efficient**.  Because every state
-has to collect much the same data and submit it to HUD in much the
-same way, the software to support that data collection and submission
-has the same core requirements in every state.  Whenever that
-circumstance exists (and it exists quite often), there is an
-opportunity to develop an open-source approach that eases the path to
-compliance for all states.

--- a/appendix-resources-tools.md
+++ b/appendix-resources-tools.md
@@ -14,20 +14,17 @@ DPG project!
 
 **Engaging Open Source Networks**
 
-(TODO: Sunita wanted to provide some thoughts on how to find
-associations or networks on OS + how to access global networks if
-local ones are not strong yet.  We're asking around for
-recommendations specific to Global South, hoping to find a
-recommendation that comes from experience.  There are so many
-resources out there... The Introduction currently notes to look at the
-Appendix for a few suggestions on this topic.)
-
-* Europe lists some, many useful globally too -- https://joinup.ec.europa.eu/collection/open-source-observatory-osor/about
-* Africa regions?
-* South America?
-* India?
-* SE Asia?
-
+**FUTURE WORK**: It would be great to offer some information here on
+how to find associations or networks for open source, and how to
+access global networks if local ones are not strong yet.  There are so
+many resources out there.  Note that in the
+[introduction](introduction.md#introduction), we already offer the
+advice to look in [Appendix: Resources and
+Tools](appendix-resources-tools.md#appendix-resources-and-tools) for
+some suggestions on this.  In Europe, there is the [Open Source
+Observatory](https://joinup.ec.europa.eu/collection/open-source-observatory-osor).
+But it would be good to present similar resources for Africa, South
+America, India, and Southeast Asia.
 
 You might also start by connecting with your local university,
 especially if there's a computer science or data science program.

--- a/community.md
+++ b/community.md
@@ -37,9 +37,7 @@ on Mifos.  Mifos has a lot of partners.  On an initial look we didn't
 find a lot of them showing up in the public repository -- maybe we
 didn't know the right places to look, though.  The development forum
 mailing list is pretty diverse, however, so on that basis it's fair to
-say the project has some diversity.  The Mifos web site also mentions
-a marketplace/app store but we couldn't find a link or other reference
-online.
+say the project has some diversity.  
 
 **KEY RECOMMENDATION**: Encourage commercial participation to improve a DPG's 
 adoption and sustainability, but take care to foster

--- a/community.md
+++ b/community.md
@@ -32,12 +32,14 @@ provide a broad array of supporting services around the financial
 inclusion DPG [Mifos](https://mifos.org/), from custom development and
 hosting to business consulting and deployment support.
 
-(TODO: MIFOS has a lot of partners but I don't see a lot of them
-showing up in the public repo. I quickly looked at dev forum mailing
-list and it seems pretty diverse, so I think the above is fair enough
-to say. Not sure if an example comes to someone else's mind? Mifos web
-site also says they have a marketplace/app store but I couldn't find a
-link or other reference online...)
+**FUTURE WORK**: It would be useful to do some more in-depth research
+on Mifos.  Mifos has a lot of partners.  On an initial look we didn't
+find a lot of them showing up in the public repository -- maybe we
+didn't know the right places to look, though.  The development forum
+mailing list is pretty diverse, however, so on that basis it's fair to
+say the project has some diversity.  The Mifos web site also mentions
+a marketplace/app store but we couldn't find a link or other reference
+online.
 
 **KEY RECOMMENDATION**: Encourage commercial participation to improve a DPG's 
 adoption and sustainability, but take care to foster

--- a/policy.md
+++ b/policy.md
@@ -119,17 +119,6 @@ Government policies matter because they direct national attention and
 funding, set boundaries for private business and investment, and shape
 a narrative around what matters and why.
 
-(TBD: [@imahgoub
-says](https://github.com/unicef/publicgoods-toolkit/pull/24#discussion_r658086768):
-"I would recommend an overview of the role policy plays in regulating
-government software and creating (or not) an enabling environment for
-leveraging DPGs."  SUSY adds: leaving this comment here until we
-confirm this revision works.  There's a lot more that could be said
-here of course but I'm not sure it's useful to an operational focused
-toolkit.  Advocacy to create an appropriately integrated, supportive,
-self-reinforcing policy environment seems out of scope and these policy makers
-aren't the audience, as I understand it?)
-
 In this module, we narrow in on a few high-level policy considerations
 that DPGs are most likely to encounter and need to consider.  Many of
 these policy considerations flow from the legal structures within
@@ -353,10 +342,6 @@ using different words, your copyright monopoly cannot prevent that.
 (Monopoly on methods and mechanisms is instead the domain of patent
 law, which we discuss [elsewhere](#patent) in this module.)
 
-(TBD: Not sure whether it's worth mentioning the "droits moraux
-d'auteurs" aspect of copyright law that exists in some jurisdictions.
-That may or may not be a useful detail for DPG policy.)
-
 Thus open-source licenses are simply formal statements by the
 copyright holder, granting explicit permission to copy and share
 without limitation, including sharing modified versions.  open-source
@@ -568,7 +553,7 @@ of a DPG (or of some aspect of a DPG).  In some cases it may even be
 desirable: while a DPG can be "forked" -- that is, anyone can make a
 divergent version with their own changes, perhaps even with changes
 that the original authors disagree with (see the
-[Adoptability](adoptability.md#adoptability) module for more on this topic) -- it may be
+[Adoptability](adoptability.md#adoptability-assessment) module for more on this topic) -- it may be
 beneficial to the public to force the fork to distinguish itself
 clearly from the original, that is, to avoid being an impostor.
 Trademarks can be powerful tools for preventing abuse and thus
@@ -733,11 +718,12 @@ Development](https://digitalprinciples.org/principle/address-privacy-security/)
 that many mitigations can be phased, especially those you deem low
 risk and low probabilty.
 
-(TODO: I feel we need to make the above point re: low resource
-environments but I am not sure what else to add about possible
-resources or next steps.  UNICEF might know more about what
-coordination, capacity building and support might be going on this
-area? Or a program of their own that might be in the future?)
+**FUTURE WORK**: Having made the above point about low-resource
+environments, it would be good to also add some material about
+possible resources or next steps.  UNICEF might know more about what
+coordination, capacity building and support might be available for
+such environments?  Or perhaps might even have, or have in the future,
+a program of their own that might be suitable?
 
 **KEY RECOMMENDATION**: Do not rely on security through obscurity: secrecy doesn't 
 equal security. Open-source software provides the conditions for stronger security
@@ -902,7 +888,7 @@ identified security threats (which don't necessarily equate 1:1 with
 regulatory non-compliance).  Security risk assessments are geared to
 be more diagnostic and forward-looking and aim to help you in project
 planning, as opposed to the security audits we note in the
-[Adoptability](adoptability.md#adoptability) module, which analyze if
+[Adoptability](adoptability.md#adoptability-assessment) module, which analyze if
 security is meeting certain standards at a specific point in time.
 There are guides and models for doing security risk assessments, such
 as from the United States National Institute of Standards and
@@ -921,10 +907,6 @@ and the International Organization for Standardization (ISO), to
 create a [security
 assessment](https://www.measureevaluation.org/resources/publications/tr-20-413.html)
 that made more sense for on-the-ground circumstances.
-
-(TODO: any tools or templates that OTS has had experience with that
-we'd want to reference here? I'm unsure what a good right level one
-might be, esp one that has the right imprimatur)
 
 You'll also come up with potential treatments for each risk.  Remember
 to include "do nothing" along with proactive and reactive options, as
@@ -1047,14 +1029,11 @@ early in the design process so security, privacy, and
 rights-supporting decisions could be reflected in the product's
 architecture.  However, as legal frameworks and other needs differ
 across deployments, the team instituted an additional step of creating Data Protection Impact
-Assessments (see below) during the
+Assessments (see more about DPIAs under [GDPR](#gdpr)) during the
 design stage of deployment customization to be sure they were fully
 meeting the requirements of local regulation as well as of local aid
 workers, government agencies, and the vulnerable populations they
 serve.
-
-(TODO: Fix the above within-page internal reference to DPIAs if possible, I can't 
-figure it out)
 
 Data privacy also depends on thoughtful design matched with
 appropriate end-to-end security support.  The right privacy policies
@@ -1099,10 +1078,8 @@ related best practice recommendations around the various types of
 open data, from non-personally-identifiable but user-contributed data to sensor data?
 
 While this paper can't review the nuances and implications of all data
-privacy and protection laws, see the [GDPR](#GDPR) section below for
+privacy and protection laws, see the [GDPR](#gdpr) section below for
 practical advice that we feel is applicable to all projects.
-
-(TODO: fix above internal link)
 
 Data privacy regulations and laws are all based on the [OECD's Privacy
 Principles](http://oecdprivacy.org) from the 1970s.  In brief, they
@@ -1444,8 +1421,6 @@ critical to making software available to more diverse, global populations.
 The DPG OpenSRP project's list of [contribution
 types](https://smartregister.org/governance-structure/) gives you an
 idea of the possible breadth of community participation.
-
-(TODO: is "not yet published" above ok to cite?)
 
 **KEY RECOMMENDATION**: Think through your DPG's local ecosystem and
 consider opportunities for collaboration with academia, keeping in

--- a/procurement.md
+++ b/procurement.md
@@ -1,12 +1,5 @@
 # Procurement
 
-(TBD: The original title of this module -- that is, the title for its
-main section, given above after the single "#" -- was as follows:
-"FOSS Procurement For Government Agencies {#procurement}".  Karl
-simplified it in order to match the relatively simple top-level names
-of the other modules, but he is open to feedback on that decision!)
-
-
 **KEY RECOMMENDATION**: Use modular contracting to better connect
 the right vendor to the right task, break vendor lock-in, and reduce
 risks associated with any one vendor. Modular contracting works best with an agile
@@ -591,19 +584,17 @@ experience. For a fuller description of what OSQA entails, please see
 a sample statement of work that includes OSQA in the 
 [Appendix: Sample Contract Language](appendix-sample-contract.md#open-source-quality-assurance).
 
-There are a variety of OSQA techniques one can introduce.  OSQA "sits
-on the tree" and enforces standards at the pull request stage.  This
-means OSQA approval is needed before source code changes can be
+There are a variety of OSQA techniques one can introduce.  OSQA can
+act as a gateway that enforces standards at the pull request stage.
+This means OSQA approval is needed before source code changes can be
 incorporated into the project.  Because incorporating changes to
 source code is a required deliverable for all software development
-vendors, when OSQA sits on the tree, it prevents vendors from
+vendors, this method prevents vendors from
 fulfilling contractual milestones unless they meet quality standards.
 Vendors soon realize they cannot invoice if they do not deliver
 approved code, which provides OSQA an entry point into a collaborative
 discussion about best practices that deliver high-quality code that
 passes approval standards quickly.
-
-(TODO: Find another term of describing "sit on the tree")
 
 OSQA enforces policies about testing, adherence to design
 guidelines, accessibility compliance, and communications (e.g. as


### PR DESCRIPTION
Handle all the TODO/TBD markers except for one in Adoptability about
making an Evaluation Checklist.

  - For obsolete markers, just remove them.

  - For quickly addressable ones, address them (e.g., make the
    "GDPR" link work, remove the "OpenHMIS" example as predicted,
    fix the language about OSQA, etc).

  - For really substantial ones, convert to a "FUTURE WORK" marker.

  - Along the way, fix some "#adoptability-assessment" links that
    were broken, although they weren't marked with "TODO" or "TBD".