### PR TITLE
Add Download PDF link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,12 +44,11 @@ const config = {
         //   src: 'img/logo.svg',
         // },
         items: [
-          // {
-          //   type: 'doc',
-          //   docId: 'intro',
-          //   position: 'left',
-          //   label: 'Tutorial',
-          // },
+          {
+            position: 'left',
+            label: 'Download PDF',
+            href: 'https://github.com/unicef/publicgoods-toolkit/releases/download/v0.1.0/publicgoods-toolkit.pdf',
+          },
           // {to: '/blog', label: 'Blog', position: 'left'},
           {
             href: 'https://github.com/unicef/publicgoods-toolkit',
@@ -88,12 +87,17 @@ const config = {
             ],
           },
           {
-            title: 'More',
+            title: 'Download',
             items: [
-              // {
-              //   label: 'Blog',
-              //   to: '/blog',
-              // },
+              {
+                label: 'Toolkit PDF',
+                href: 'https://github.com/unicef/publicgoods-toolkit/releases/download/v0.1.0/publicgoods-toolkit.pdf',
+              },
+            ],
+          },
+          {
+            title: 'Contribute',
+            items: [
               {
                 label: 'GitHub',
                 href: 'https://github.com/unicef/publicgoods-toolkit',

--- a/pdf/Makefile
+++ b/pdf/Makefile
@@ -18,7 +18,7 @@ html: $(SOURCES)
 	@echo "HTML output is not yet implemented."
 
 # The version number is what follows the word "version" in the title.
-VERSION := "0.0"
+VERSION := "0.1.0"
 
 # The rule is "pdf-preamble" not "pdf-preamble.yaml" because we don't
 # want it to refuse to rebuild the .yaml file when that file appears


### PR DESCRIPTION
Now that the docusaurus site is live already, and having published the first release as part of this code repository in the form of the PDF, this PR adds a `Download PDF` link in the navbar that points to the release, as illustrated in the screenshot below:

![Screen Shot 2021-12-02 at 4 24 56 PM](https://user-images.githubusercontent.com/6098973/144519034-3a7a8097-c41e-457b-b599-6ba393d85552.png)


ToDo: automate the publication of new versions of the PDF and update this link accordingly which is left for a subsequent PR.