### PR TITLE
DOC: add README for PDF generation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,7 +47,7 @@ const config = {
           {
             position: 'left',
             label: 'Download PDF',
-            href: 'https://github.com/unicef/publicgoods-toolkit/releases/download/v0.1.0/publicgoods-toolkit.pdf',
+            href: 'https://github.com/unicef/publicgoods-toolkit/releases/latest/download/publicgoods-toolkit.pdf',
           },
           // {to: '/blog', label: 'Blog', position: 'left'},
           {
@@ -91,7 +91,7 @@ const config = {
             items: [
               {
                 label: 'Toolkit PDF',
-                href: 'https://github.com/unicef/publicgoods-toolkit/releases/download/v0.1.0/publicgoods-toolkit.pdf',
+                href: 'https://github.com/unicef/publicgoods-toolkit/releases/latest/download/publicgoods-toolkit.pdf',
               },
             ],
           },

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -1,0 +1,29 @@
+# PDF Generation of Toolkit
+
+The contents of this folder are used towards the automated generation of a PDF of the Digital Public Goods Toolkit. This is accomplished through the preprocessing and subsequent collating of selected Markdown files to output a single PDF file.
+
+## Requirements
+
+Generating a PDF, requires both `pandoc` (v2.9 or higher) and `TeX` to be installed in the system.
+
+* MacOS: Run the following commands to install the necessary dependencies
+
+	```bash
+	brew install pandoc
+	brew install basictex
+	sudo tlmgr update --self
+	sudo tlmgr install titlesec
+	```
+
+## Generate the PDF
+
+Simply run `make` inside this folder:
+
+```bash
+cd pdf
+make
+```
+
+which will output a file named `publicgoods-toolkit-{version}.pdf`.
+
+Refer to the inline documentation in the [Makefile](Makefile) for the specific steps in preprocessing and correctly ordering the Markdown files, and [CONTRIBUTING](../CONTRIBUTING.md) for the conventions used throughout this project to maintain consistency.

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -24,6 +24,6 @@ cd pdf
 make
 ```
 
-which will output a file named `publicgoods-toolkit-{version}.pdf`.
+which will output a file named `publicgoods-toolkit.pdf`.
 
 Refer to the inline documentation in the [Makefile](Makefile) for the specific steps in preprocessing and correctly ordering the Markdown files, and [CONTRIBUTING](../CONTRIBUTING.md) for the conventions used throughout this project to maintain consistency.

--- a/pdf/README.md
+++ b/pdf/README.md
@@ -4,7 +4,7 @@ The contents of this folder are used towards the automated generation of a PDF o
 
 ## Requirements
 
-Generating a PDF, requires both `pandoc` (v2.9 or higher) and `TeX` to be installed in the system.
+Generating a PDF requires both `pandoc` (v2.9 or higher) and `TeX` to be installed in the system.
 
 * MacOS: Run the following commands to install the necessary dependencies
 


### PR DESCRIPTION
As per [this comment](https://github.com/unicef/publicgoods-toolkit/issues/65#issuecomment-985038992), I am hereby adding a README to the `pdf/` folder to document how to create the PDF from the Markdown files (and installing the necessary dependencies). It's admittedly very basic, but that's all the information I would need to accomplish this task.