### PR TITLE
BLD: autoversioning and release PDF

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: release
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs: 
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y texlive-latex-base texlive-latex-recommended texlive-latex-extra;
+          wget https://github.com/jgm/pandoc/releases/download/2.16.2/pandoc-2.16.2-1-amd64.deb
+          sudo dpkg -i pandoc-2.16.2-1-amd64.deb
+      - name: Create release
+        id: release
+        uses: rymndhng/release-on-push-action@master
+        with:
+          bump_version_scheme: patch
+          tag_prefix: v
+      - name: Generate build artifacts
+        run: cd pdf && make
+        env:
+          PDF_VERSION: ${{ steps.release.outputs.tag_name }}
+      - name: Check Output Parameters
+        run: |
+          echo "Got tag name ${{ steps.release.outputs.tag_name }}"
+          echo "Got release version ${{ steps.release.outputs.version }}"
+      - name: Upload the artifacts to release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: 'pdf/publicgoods-toolkit.pdf'
+          asset_name: 'publicgoods-toolkit.pdf'
+          overwrite: true
+          tag: ${{ steps.release.outputs.tag_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # Repository-specific files
+ublicgoods-toolkit.pdf
 publicgoods-toolkit-v*.pdf
 publicgoods-toolkit-v*.html
 .everything.md

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ yarn-debug.log*
 yarn-error.log*
 
 # Repository-specific files
-ublicgoods-toolkit.pdf
+publicgoods-toolkit.pdf
 publicgoods-toolkit-v*.pdf
 publicgoods-toolkit-v*.html
 .everything.md

--- a/pdf/Makefile
+++ b/pdf/Makefile
@@ -18,7 +18,11 @@ html: $(SOURCES)
 	@echo "HTML output is not yet implemented."
 
 # The version number is what follows the word "version" in the title.
-VERSION := "0.1.0"
+# PDF_VERSION should be passed as an environment variable, but will
+# default to 0.1.0 if not present.
+# An easy way to specify it at runtime would be to run:
+# PDF_VERSION=v0.3.0 make
+PDF_VERSION ?= "0.1.0"
 
 # The rule is "pdf-preamble" not "pdf-preamble.yaml" because we don't
 # want it to refuse to rebuild the .yaml file when that file appears
@@ -27,7 +31,7 @@ VERSION := "0.1.0"
 # Also, yes, there is a 'sed' command in the 'sed' command below :-).
 pdf-preamble: pdf-preamble.yaml.in
 	@cat pdf-preamble.yaml.in  | sed -e "s/__DATE__/`date +'%d %B %Y' | sed -e 's/^0//g'`/" > pdf-preamble.yaml.tmp
-	@cat pdf-preamble.yaml.tmp | sed -e "s/__VERSION__/$(VERSION)/" > pdf-preamble.yaml
+	@cat pdf-preamble.yaml.tmp | sed -e "s/__VERSION__/$(PDF_VERSION)/" > pdf-preamble.yaml
 	@rm pdf-preamble.yaml.tmp
 
 # There are three ways we control the PDF output: 
@@ -101,5 +105,5 @@ pdf: pdf-preamble $(SOURCES)
                 --toc                                                     \
                 --toc-depth=5                                             \
                 --number-sections                                         \
-                -o publicgoods-toolkit-v$(VERSION).pdf                    \
+                -o publicgoods-toolkit.pdf                    \
                 .everything.md


### PR DESCRIPTION
This is so beautiful ❤️

Everytime a new commit or a new pull request is merged onto the `main` branch the GitHub Actions code in `.github/workflows/release.yml` is run which does the following:
- Checkout the code
- Create a new release automatically increasing the `patch` version following Semantic Versioning
- Generate a PDF version of the toolkit using the tag obtained in the previous step
- Upload the generated PDF to the newly created release

This code has been thoroughly tested in the [lacabra/publicgoods-toolkit](https://github.com/lacabra/publicgoods-toolkit) repo, where you can see the last couple of releases with the corresponding PDFs.

Also, thanks to the changes pushed in 3cd8884, the website will always point to the `latest` version of the PDF without having to update the link to each version every time a new release comes out.